### PR TITLE
Load and visualize points from napari

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 -   Add possibility of custom input widgets for algorithms
 -   Switch to napari Colormaps instead of custom one
+-   Add points visualization
 
 ## 0.12.6
 

--- a/package/PartSeg/_roi_analysis/partseg_settings.py
+++ b/package/PartSeg/_roi_analysis/partseg_settings.py
@@ -71,13 +71,6 @@ class PartSettings(BaseSettings):
         self.compare_segmentation = segmentation
         self.compare_segmentation_change.emit(segmentation)
 
-    @property
-    def use_physical_unit(self):
-        return self.get("use_physical_unit", False)
-
-    def set_use_physical_unit(self, value):
-        self.set("use_physical_unit", value)
-
     def _image_changed(self):
         super()._image_changed()
         self._mask = None

--- a/package/PartSeg/_roi_analysis/partseg_settings.py
+++ b/package/PartSeg/_roi_analysis/partseg_settings.py
@@ -125,7 +125,7 @@ class PartSettings(BaseSettings):
         elif isinstance(data, MaskInfo):
             self.mask = data.mask_array
         elif isinstance(data, PointsInfo):
-            self.points = data
+            self.points = data.points
 
     def get_save_list(self) -> typing.List[SaveSettingsDescription]:
         return super().get_save_list() + [

--- a/package/PartSeg/_roi_analysis/partseg_settings.py
+++ b/package/PartSeg/_roi_analysis/partseg_settings.py
@@ -100,6 +100,7 @@ class PartSettings(BaseSettings):
             mask=self.mask,
             history=self.history[: self.history_index + 1],
             algorithm_parameters=algorithm_val,
+            points=self.points,
         )
 
     def set_project_info(self, data: typing.Union[ProjectTuple, MaskInfo, PointsInfo]):

--- a/package/PartSeg/_roi_analysis/partseg_settings.py
+++ b/package/PartSeg/_roi_analysis/partseg_settings.py
@@ -11,7 +11,7 @@ from PartSegCore.analysis.io_utils import MaskInfo, ProjectTuple
 from PartSegCore.analysis.load_functions import load_metadata
 from PartSegCore.analysis.measurement_calculation import MeasurementProfile
 from PartSegCore.analysis.save_hooks import PartEncoder
-from PartSegCore.io_utils import HistoryElement
+from PartSegCore.io_utils import HistoryElement, PointsInfo
 from PartSegCore.json_hooks import ProfileDict
 from PartSegCore.roi_info import ROIInfo
 
@@ -102,7 +102,7 @@ class PartSettings(BaseSettings):
             algorithm_parameters=algorithm_val,
         )
 
-    def set_project_info(self, data: typing.Union[ProjectTuple, MaskInfo]):
+    def set_project_info(self, data: typing.Union[ProjectTuple, MaskInfo, PointsInfo]):
         if isinstance(data, ProjectTuple):
             if self.image.file_path == data.image.file_path and self.image.shape == data.image.shape:
                 if data.roi is not None:
@@ -124,6 +124,8 @@ class PartSettings(BaseSettings):
                 self.algorithm_changed.emit()
         elif isinstance(data, MaskInfo):
             self.mask = data.mask_array
+        elif isinstance(data, PointsInfo):
+            self.points = data
 
     def get_save_list(self) -> typing.List[SaveSettingsDescription]:
         return super().get_save_list() + [

--- a/package/PartSeg/_roi_mask/stack_settings.py
+++ b/package/PartSeg/_roi_mask/stack_settings.py
@@ -120,6 +120,7 @@ class StackSettings(BaseSettings):
             selected_components=self.chosen_components(),
             roi_extraction_parameters=copy(self.components_parameters_dict),
             history=self.history[: self.history_index + 1],
+            points=self.points,
         )
 
     def set_project_info(self, data: typing.Union[MaskProjectTuple, PointsInfo]):

--- a/package/PartSeg/_roi_mask/stack_settings.py
+++ b/package/PartSeg/_roi_mask/stack_settings.py
@@ -9,7 +9,7 @@ from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QMessageBox
 
 from PartSegCore.algorithm_describe_base import ROIExtractionProfile
-from PartSegCore.io_utils import HistoryElement, HistoryProblem
+from PartSegCore.io_utils import HistoryElement, HistoryProblem, PointsInfo
 from PartSegCore.mask.io_functions import MaskProjectTuple, load_metadata
 from PartSegCore.segmentation.algorithm_base import SegmentationResult
 from PartSegImage import Image
@@ -122,10 +122,14 @@ class StackSettings(BaseSettings):
             history=self.history[: self.history_index + 1],
         )
 
-    def set_project_info(self, data: MaskProjectTuple):
+    def set_project_info(self, data: typing.Union[MaskProjectTuple, PointsInfo]):
         """signals = self.signalsBlocked()
         if data.segmentation is not None:
             self.blockSignals(True)"""
+
+        if isinstance(data, PointsInfo):
+            self.points = data.points
+            return
         if isinstance(data.image, Image) and (
             self.image_path != data.image.file_path or self.image_shape != data.image.shape
         ):

--- a/package/PartSeg/_roi_mask/stack_settings.py
+++ b/package/PartSeg/_roi_mask/stack_settings.py
@@ -32,13 +32,13 @@ class StackSettings(BaseSettings):
     ]
 
     def set_segmentation_result(self, result: SegmentationResult):
-        if self._parent and np.max(result.roi) == 0:
+        if self._parent and np.max(result.roi) == 0:  # pragma: no cover
             QMessageBox.information(
                 self._parent,
                 "No result",
                 "Segmentation contains no component, check parameters, especially chosen channel.",
             )
-        if result.info_text and self._parent is not None:
+        if result.info_text and self._parent is not None:  # pragma: no cover
             QMessageBox().information(self._parent, "Algorithm info", result.info_text)
         parameters_dict = defaultdict(lambda: deepcopy(result.parameters))
         self._additional_layers = result.additional_layers
@@ -78,7 +78,7 @@ class StackSettings(BaseSettings):
         if self.chosen_components_widget is not None:
             return sorted(self.chosen_components_widget.get_chosen())
 
-        raise RuntimeError("chosen_components_widget do not initialized")
+        raise RuntimeError("chosen_components_widget do not initialized")  # pragma: no cover
 
     def component_is_chosen(self, val: int) -> bool:
         """
@@ -90,7 +90,7 @@ class StackSettings(BaseSettings):
         if self.chosen_components_widget is not None:
             return self.chosen_components_widget.get_state(val)
 
-        raise RuntimeError("chosen_components_widget do not idealized")
+        raise RuntimeError("chosen_components_widget do not idealized")  # pragma: no cover
 
     def components_mask(self) -> np.ndarray:
         """
@@ -102,7 +102,7 @@ class StackSettings(BaseSettings):
         if self.chosen_components_widget is not None:
             return self.chosen_components_widget.get_mask()
 
-        raise RuntimeError("chosen_components_widget do not initialized")
+        raise RuntimeError("chosen_components_widget do not initialized")  # pragma: no cover
 
     def get_project_info(self) -> MaskProjectTuple:
         """
@@ -251,16 +251,6 @@ class StackSettings(BaseSettings):
                 return False
         return True
 
-    def set_project_data(self, data: MaskProjectTuple, save_chosen=True):
-        if isinstance(data.image, Image):
-            self.image = data.image
-        if data.roi is not None:
-            if not self.compare_history(data.history) and data.selected_components:
-                raise HistoryProblem("Incompatible history")
-            self.set_history(data.history)
-            self.mask = data.mask
-            self.set_segmentation(data.roi, save_chosen, data.selected_components, data.roi_extraction_parameters)
-
     def set_segmentation(
         self, new_segmentation_data, save_chosen=True, list_of_components=None, segmentation_parameters=None
     ):
@@ -294,18 +284,21 @@ class StackSettings(BaseSettings):
             self.components_parameters_dict = segmentation_parameters
 
 
-def get_mask(segmentation: typing.Optional[np.ndarray], mask: typing.Optional[np.ndarray], selected: typing.List[int]):
+def get_mask(
+    segmentation: typing.Optional[np.ndarray], mask: typing.Optional[np.ndarray], selected: typing.List[int]
+) -> np.ndarray:
     """
     Calculate mask base on segmentation, current mask and list of chosen components.
+    Its exclude selected components from mask.
 
     :param typing.Optional[np.ndarray] segmentation: segmentation array
     :param typing.Optional[np.ndarray] mask: current mask
-    :param typing.List[int] selected: list of selected components
+    :param typing.List[int] selected: list of selected components which should be masked as non segmentation area
     :return: new mask
     :rtype: typing.Optional[np.ndarray]
     """
     if segmentation is None or len(selected) == 0:
-        return None if mask is None else mask
+        return mask
     segmentation = reduce_array(segmentation, selected)
     if mask is None:
         resp = np.ones(segmentation.shape, dtype=np.uint8)

--- a/package/PartSeg/common_backend/base_settings.py
+++ b/package/PartSeg/common_backend/base_settings.py
@@ -443,9 +443,8 @@ class BaseSettings(ViewSettings):
 
     @points.setter
     def points(self, value):
-        print(value)
         if value is not None:
-            self._points = value.points
+            self._points = value
         else:
             self._points = None
         self.points_changed.emit()

--- a/package/PartSeg/common_backend/base_settings.py
+++ b/package/PartSeg/common_backend/base_settings.py
@@ -411,6 +411,7 @@ class BaseSettings(ViewSettings):
     """
 
     mask_changed = Signal()
+    points_changed = Signal()
     mask_representation_changed = Signal()
     request_load_files = Signal(list)
     """:py:class:`~.Signal` mask changed signal"""
@@ -430,6 +431,24 @@ class BaseSettings(ViewSettings):
         self.history: List[HistoryElement] = []
         self.history_index = -1
         self.last_executed_algorithm = ""
+        self._points = None
+
+    def _image_changed(self):
+        super()._image_changed()
+        self.points = None
+
+    @property
+    def points(self):
+        return self._points
+
+    @points.setter
+    def points(self, value):
+        print(value)
+        if value is not None:
+            self._points = value.points
+        else:
+            self._points = None
+        self.points_changed.emit()
 
     def set_segmentation_result(self, result: SegmentationResult):
         if result.info_text and self._parent is not None:

--- a/package/PartSeg/common_gui/main_window.py
+++ b/package/PartSeg/common_gui/main_window.py
@@ -204,6 +204,8 @@ class BaseMainWindow(QMainWindow):
             viewer.add_labels(self.settings.roi, name="ROI", scale=scaling)
         if image.mask is not None:
             viewer.add_labels(image.mask, name="Mask", scale=scaling)
+        if self.settings.points is not None:
+            viewer.add_points(self.settings.points, name="Points", scale=scaling)
         self.viewer_list.append(viewer)
         viewer.window.qt_viewer.destroyed.connect(lambda x: self.close_viewer(viewer))
 

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -12,7 +12,7 @@ except ImportError:
     from napari._qt.qt_viewer_buttons import QtViewerPushButton
 
 from napari.components import ViewerModel as Viewer
-from napari.layers import Layer
+from napari.layers import Layer, Points
 from napari.layers.image import Image as NapariImage
 from napari.layers.image._image_constants import Interpolation3D
 from napari.layers.labels import Labels
@@ -159,6 +159,7 @@ class ImageView(QWidget):
         self._current_order = "xy"
         self.components = None
         self.worker_list = []
+        self.points_layer = Points(ndim=4)
 
         self.viewer = Viewer(ndisplay=ndisplay)
         self.viewer.theme = self.settings.theme_name
@@ -172,6 +173,7 @@ class ImageView(QWidget):
         self.roll_dim_button.customContextMenuRequested.connect(self._dim_order_menu)
         self.mask_chk = QCheckBox()
         self.mask_label = QLabel("Mask:")
+        self.viewer.add_layer(self.points_layer)
 
         self.btn_layout = QHBoxLayout()
         self.btn_layout.addWidget(self.reset_view_button)
@@ -197,6 +199,7 @@ class ImageView(QWidget):
         settings.roi_clean.connect(self.set_roi)
         settings.image_changed.connect(self.set_image)
         settings.image_spacing_changed.connect(self.update_spacing_info)
+        settings.points_changed.connect(self.update_points)
         # settings.labels_changed.connect(self.paint_layer)
         self.old_scene: BaseCamera = self.viewer_widget.view.scene
 
@@ -353,6 +356,17 @@ class ImageView(QWidget):
         if self.current_image not in self.image_info:
             return self.settings.image
         return self.image_info[self.current_image].image
+
+    def update_points(self):
+        if self.settings.points is not None:
+            if self.points_layer not in self.viewer.layers:
+                self.points_layer = Points(self.settings.points, scale=self.settings.image.normalized_scaling())
+                self.viewer.add_layer(self.points_layer)
+            else:
+                self.points_layer.data = self.settings.points
+                self.points_layer.scale = self.settings.image.normalized_scaling()
+        else:
+            self.points_layer.data = np.empty((0, 4))
 
     def set_roi(self, roi_info: Optional[ROIInfo] = None, image: Optional[Image] = None) -> None:
         image = self.get_image(image)

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -168,6 +168,9 @@ class ImageView(QWidget):
         self.channel_control = ColorComboBoxGroup(settings, name, channel_property, height=30)
         self.ndim_btn = QtNDisplayButton(self.viewer)
         self.reset_view_button = QtViewerPushButton(self.viewer, "home", "Reset view", self._reset_view)
+        self.points_view_button = QtViewerPushButton(
+            self.viewer, "new_points", "Show points", self.toggle_points_visibility
+        )
         self.roll_dim_button = QtViewerPushButton(self.viewer, "roll", "Roll dimension", self._rotate_dim)
         self.roll_dim_button.setContextMenuPolicy(Qt.CustomContextMenu)
         self.roll_dim_button.customContextMenuRequested.connect(self._dim_order_menu)
@@ -179,6 +182,7 @@ class ImageView(QWidget):
         self.btn_layout.addWidget(self.reset_view_button)
         self.btn_layout.addWidget(self.ndim_btn)
         self.btn_layout.addWidget(self.roll_dim_button)
+        self.btn_layout.addWidget(self.points_view_button)
         self.btn_layout.addWidget(self.channel_control, 1)
         self.btn_layout.addWidget(self.mask_label)
         self.btn_layout.addWidget(self.mask_chk)
@@ -220,6 +224,10 @@ class ImageView(QWidget):
             self.viewer.dims.events.camera.connect(self._view_changed, position="last")
             self.viewer.dims.events.camera.connect(self.camera_change, position="last")
         self.viewer.events.reset_view.connect(self._view_changed, position="last")
+
+    def toggle_points_visibility(self):
+        if self.points_layer is not None:
+            self.points_layer.visible = not self.points_layer.visible
 
     def _dim_order_menu(self, point: QPoint):
         menu = QMenu()
@@ -359,6 +367,7 @@ class ImageView(QWidget):
 
     def update_points(self):
         if self.settings.points is not None:
+            self.points_view_button.setVisible(True)
             if self.points_layer not in self.viewer.layers:
                 self.points_layer = Points(self.settings.points, scale=self.settings.image.normalized_scaling())
                 self.viewer.add_layer(self.points_layer)
@@ -366,6 +375,7 @@ class ImageView(QWidget):
                 self.points_layer.data = self.settings.points
                 self.points_layer.scale = self.settings.image.normalized_scaling()
         else:
+            self.points_view_button.setVisible(False)
             self.points_layer.data = np.empty((0, 4))
 
     def set_roi(self, roi_info: Optional[ROIInfo] = None, image: Optional[Image] = None) -> None:

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -159,7 +159,7 @@ class ImageView(QWidget):
         self._current_order = "xy"
         self.components = None
         self.worker_list = []
-        self.points_layer = Points(ndim=4)
+        self.points_layer = None
 
         self.viewer = Viewer(ndisplay=ndisplay)
         self.viewer.theme = self.settings.theme_name
@@ -176,7 +176,6 @@ class ImageView(QWidget):
         self.roll_dim_button.customContextMenuRequested.connect(self._dim_order_menu)
         self.mask_chk = QCheckBox()
         self.mask_label = QLabel("Mask:")
-        self.viewer.add_layer(self.points_layer)
 
         self.btn_layout = QHBoxLayout()
         self.btn_layout.addWidget(self.reset_view_button)
@@ -375,8 +374,9 @@ class ImageView(QWidget):
                 self.points_layer.data = self.settings.points
                 self.points_layer.scale = self.settings.image.normalized_scaling()
         else:
-            self.points_view_button.setVisible(False)
-            self.points_layer.data = np.empty((0, 4))
+            if self.points_layer in self.viewer.layers:
+                self.points_view_button.setVisible(False)
+                self.points_layer.data = np.empty((0, 4))
 
     def set_roi(self, roi_info: Optional[ROIInfo] = None, image: Optional[Image] = None) -> None:
         image = self.get_image(image)

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -367,14 +367,14 @@ class ImageView(QWidget):
     def update_points(self):
         if self.settings.points is not None:
             self.points_view_button.setVisible(True)
-            if self.points_layer is not None and self.points_layer not in self.viewer.layers:
+            if self.points_layer is not None or self.points_layer not in self.viewer.layers:
                 self.points_layer = Points(self.settings.points, scale=self.settings.image.normalized_scaling())
                 self.viewer.add_layer(self.points_layer)
             else:
                 self.points_layer.data = self.settings.points
                 self.points_layer.scale = self.settings.image.normalized_scaling()
         else:
-            if self.points_layer is not None and self.points_layer in self.viewer.layers:
+            if self.points_layer is not None or self.points_layer in self.viewer.layers:
                 self.points_view_button.setVisible(False)
                 self.points_layer.data = np.empty((0, 4))
 

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -367,14 +367,14 @@ class ImageView(QWidget):
     def update_points(self):
         if self.settings.points is not None:
             self.points_view_button.setVisible(True)
-            if self.points_layer not in self.viewer.layers:
+            if self.points_layer is not None and self.points_layer not in self.viewer.layers:
                 self.points_layer = Points(self.settings.points, scale=self.settings.image.normalized_scaling())
                 self.viewer.add_layer(self.points_layer)
             else:
                 self.points_layer.data = self.settings.points
                 self.points_layer.scale = self.settings.image.normalized_scaling()
         else:
-            if self.points_layer in self.viewer.layers:
+            if self.points_layer is not None and self.points_layer in self.viewer.layers:
                 self.points_view_button.setVisible(False)
                 self.points_layer.data = np.empty((0, 4))
 

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -374,7 +374,7 @@ class ImageView(QWidget):
                 self.points_layer.data = self.settings.points
                 self.points_layer.scale = self.settings.image.normalized_scaling()
         else:
-            if self.points_layer is None or self.points_layer in self.viewer.layers:
+            if self.points_layer is not None and self.points_layer in self.viewer.layers:
                 self.points_view_button.setVisible(False)
                 self.points_layer.data = np.empty((0, 4))
 

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -367,14 +367,14 @@ class ImageView(QWidget):
     def update_points(self):
         if self.settings.points is not None:
             self.points_view_button.setVisible(True)
-            if self.points_layer is not None or self.points_layer not in self.viewer.layers:
+            if self.points_layer is None or self.points_layer not in self.viewer.layers:
                 self.points_layer = Points(self.settings.points, scale=self.settings.image.normalized_scaling())
                 self.viewer.add_layer(self.points_layer)
             else:
                 self.points_layer.data = self.settings.points
                 self.points_layer.scale = self.settings.image.normalized_scaling()
         else:
-            if self.points_layer is not None or self.points_layer in self.viewer.layers:
+            if self.points_layer is None or self.points_layer in self.viewer.layers:
                 self.points_view_button.setVisible(False)
                 self.points_layer.data = np.empty((0, 4))
 

--- a/package/PartSegCore/analysis/io_utils.py
+++ b/package/PartSegCore/analysis/io_utils.py
@@ -57,6 +57,13 @@ class ProjectTuple(ProjectInfoBase):
 
 
 class MaskInfo(typing.NamedTuple):
+    """
+    Structure representing mask data
+
+    :param str file_path: path to file with mask
+    :param np.ndarray mask_array: numpy array with mask information
+    """
+
     file_path: str
     mask_array: np.ndarray
 

--- a/package/PartSegCore/analysis/io_utils.py
+++ b/package/PartSegCore/analysis/io_utils.py
@@ -26,6 +26,7 @@ class ProjectTuple(ProjectInfoBase):
     history: typing.List[HistoryElement] = field(default_factory=list)
     algorithm_parameters: dict = field(default_factory=dict)
     errors: str = ""
+    points: typing.Optional[np.ndarray] = None
 
     def __post_init__(self):
         if self.roi_info.roi is not None:

--- a/package/PartSegCore/analysis/load_functions.py
+++ b/package/PartSegCore/analysis/load_functions.py
@@ -21,6 +21,7 @@ from ..algorithm_describe_base import Register, ROIExtractionProfile
 from ..io_utils import (
     HistoryElement,
     LoadBase,
+    LoadPoints,
     SegmentationType,
     UpdateLoadedMetadataBase,
     WrongFileTypeException,
@@ -406,6 +407,7 @@ class UpdateLoadedMetadataAnalysis(UpdateLoadedMetadataBase):
 def load_metadata(data: typing.Union[str, Path]):
     """
     Load metadata saved in json format for segmentation mask
+
     :param data: path to json file, string with json, or opened file
     :return: restored structures
     """
@@ -426,5 +428,5 @@ def update_algorithm_dict(dkt):
 
 
 load_dict = Register(
-    LoadStackImage, LoadImageMask, LoadProject, LoadMaskSegmentation, class_methods=LoadBase.need_functions
+    LoadStackImage, LoadImageMask, LoadProject, LoadMaskSegmentation, LoadPoints, class_methods=LoadBase.need_functions
 )

--- a/package/PartSegCore/io_utils.py
+++ b/package/PartSegCore/io_utils.py
@@ -11,6 +11,7 @@ from tarfile import TarFile, TarInfo
 
 import imageio
 import numpy as np
+import pandas as pd
 import tifffile
 from napari.utils import Colormap
 
@@ -454,3 +455,33 @@ class SaveROIAsNumpy(SaveBase):
         elif segmentation_max < 2 ** 16 - 1:
             segmentation = segmentation.astype(np.uint16)
         np.save(save_location, segmentation)
+
+
+class PointsInfo(typing.NamedTuple):
+    file_path: str
+    points: np.ndarray
+
+
+class LoadPoints(LoadBase):
+    @classmethod
+    def get_short_name(cls):
+        return "point_csv"
+
+    @classmethod
+    def load(
+        cls,
+        load_locations: typing.List[typing.Union[str, BytesIO, Path]],
+        range_changed: typing.Callable[[int, int], typing.Any] = None,
+        step_changed: typing.Callable[[int], typing.Any] = None,
+        metadata: typing.Optional[dict] = None,
+    ) -> PointsInfo:
+        df = pd.read_csv(load_locations[0], delimiter=",", index_col=0)
+        return PointsInfo(load_locations[0], df.to_numpy())
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "Points (*.csv)"
+
+    @classmethod
+    def get_fields(cls) -> typing.List[typing.Union[AlgorithmProperty, str]]:
+        return ["text"]

--- a/package/PartSegCore/mask/io_functions.py
+++ b/package/PartSegCore/mask/io_functions.py
@@ -544,8 +544,8 @@ def save_components(
             points_mask = components_mark[tuple(points_casted.T)]
             filtered_points = points[points_mask]
             lower_bound = np.min(np.nonzero(components_mark), axis=1)
-            for i in index_to_frame_points:
-                lower_bound[i] -= FRAME_THICKNESS
+            for j in index_to_frame_points:
+                lower_bound[j] -= FRAME_THICKNESS
 
             df = pd.DataFrame(filtered_points - lower_bound)
             df.to_csv(os.path.join(dir_path, f"{file_name}_component{i}.csv"))

--- a/package/PartSegCore/mask/io_functions.py
+++ b/package/PartSegCore/mask/io_functions.py
@@ -18,6 +18,7 @@ from ..algorithm_describe_base import AlgorithmProperty, Register, ROIExtraction
 from ..io_utils import (
     HistoryElement,
     LoadBase,
+    LoadPoints,
     SaveBase,
     SaveMaskAsTiff,
     SaveROIAsNumpy,
@@ -664,7 +665,9 @@ class UpdateLoadedMetadataMask(UpdateLoadedMetadataBase):
         return profile_data
 
 
-load_dict = Register(LoadStackImage, LoadROIImage, LoadStackImageWithMask, class_methods=LoadBase.need_functions)
+load_dict = Register(
+    LoadPoints, LoadStackImage, LoadROIImage, LoadStackImageWithMask, class_methods=LoadBase.need_functions
+)
 save_parameters_dict = Register(SaveParametersJSON, class_methods=SaveBase.need_functions)
 save_components_dict = Register(SaveComponents, class_methods=SaveBase.need_functions)
 save_segmentation_dict = Register(

--- a/package/PartSegCore/mask/io_functions.py
+++ b/package/PartSegCore/mask/io_functions.py
@@ -267,9 +267,7 @@ class LoadSegmentation(LoadBase):
     def fix_parameters(profile: ROIExtractionProfile):
         if profile is None:
             return
-        if (profile.algorithm == "Threshold" or profile.algorithm == "Auto Threshold") and isinstance(
-            profile.values["smooth_border"], bool
-        ):
+        if (profile.algorithm in {"Threshold", "Auto Threshold"}) and isinstance(profile.values["smooth_border"], bool):
             if profile.values["smooth_border"] and "smooth_border_radius" in profile.values:
                 profile.values["smooth_border"] = {
                     "name": "Opening",
@@ -532,7 +530,7 @@ def save_components(
     file_name = os.path.splitext(os.path.basename(image.file_path))[0]
     points_casted = None
     important_axis = "XY" if image.is_2d else "XYZ"
-    index_to_frame_points = image._calc_index_to_frame(image.axis_order, important_axis)
+    index_to_frame_points = image.calc_index_to_frame(image.axis_order, important_axis)
     if points is not None:
         points_casted = points.astype(np.uint16)
 
@@ -669,7 +667,7 @@ class UpdateLoadedMetadataMask(UpdateLoadedMetadataBase):
     @classmethod
     def update_segmentation_profile(cls, profile_data: ROIExtractionProfile) -> ROIExtractionProfile:
         profile_data = super().update_segmentation_profile(profile_data)
-        if profile_data.algorithm == "Threshold" or profile_data.algorithm == "Auto Threshold":
+        if profile_data.algorithm in {"Threshold", "Auto Threshold"}:
             if isinstance(profile_data.values["smooth_border"], bool):
                 if profile_data.values["smooth_border"]:
                     profile_data.values["smooth_border"] = {

--- a/package/PartSegCore/mask/io_functions.py
+++ b/package/PartSegCore/mask/io_functions.py
@@ -666,7 +666,7 @@ class UpdateLoadedMetadataMask(UpdateLoadedMetadataBase):
 
 
 load_dict = Register(
-    LoadPoints, LoadStackImage, LoadROIImage, LoadStackImageWithMask, class_methods=LoadBase.need_functions
+    LoadStackImage, LoadROIImage, LoadStackImageWithMask, LoadPoints, class_methods=LoadBase.need_functions
 )
 save_parameters_dict = Register(SaveParametersJSON, class_methods=SaveBase.need_functions)
 save_components_dict = Register(SaveComponents, class_methods=SaveBase.need_functions)

--- a/package/PartSegCore/mask/io_functions.py
+++ b/package/PartSegCore/mask/io_functions.py
@@ -69,6 +69,7 @@ class MaskProjectTuple(ProjectInfoBase):
     history: typing.List[HistoryElement] = dataclasses.field(default_factory=list)
     errors: str = ""
     spacing: typing.Optional[typing.List[float]] = None
+    points: typing.Optional[np.ndarray] = None
 
     def get_raw_copy(self):
         return MaskProjectTuple(self.file_path, self.image.substitute(mask=None))

--- a/package/PartSegCore/mask/io_functions.py
+++ b/package/PartSegCore/mask/io_functions.py
@@ -9,8 +9,8 @@ from io import BufferedIOBase, BytesIO, IOBase, RawIOBase, TextIOBase
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 import tifffile
+from napari.plugins._builtins import napari_write_points
 
 from PartSegImage import GenericImageReader, Image, ImageWriter, TiffImageReader
 from PartSegImage.image import FRAME_THICKNESS, reduce_array
@@ -541,12 +541,13 @@ def save_components(
         if points is not None and points_casted is not None:
             points_mask = components_mark[tuple(points_casted.T)]
             filtered_points = points[points_mask]
+            filtered_points[:, 1] = np.round(filtered_points[:, 1])
             lower_bound = np.min(np.nonzero(components_mark), axis=1)
             for j in index_to_frame_points:
                 lower_bound[j] -= FRAME_THICKNESS
-
-            df = pd.DataFrame(filtered_points - lower_bound)
-            df.to_csv(os.path.join(dir_path, f"{file_name}_component{i}.csv"))
+            napari_write_points(
+                os.path.join(dir_path, f"{file_name}_component{i}.csv"), filtered_points - lower_bound, {}
+            )
 
         # print(f"[run] {im}")
         ImageWriter.save(im, os.path.join(dir_path, f"{file_name}_component{i}.tif"))

--- a/package/PartSegCore/project_info.py
+++ b/package/PartSegCore/project_info.py
@@ -31,6 +31,7 @@ class ProjectInfoBase(Protocol):
     roi_info: ROIInfo = ROIInfo(None)
     mask: Optional[np.ndarray]
     errors: str = ""
+    points: Optional[np.ndarray] = None
 
     def get_raw_copy(self):
         """

--- a/package/PartSegImage/image.py
+++ b/package/PartSegImage/image.py
@@ -6,6 +6,7 @@ import numpy as np
 Spacing = typing.Tuple[typing.Union[float, int], ...]
 
 _DEF = object()
+FRAME_THICKNESS = 2
 
 
 def minimal_dtype(val: int):
@@ -479,8 +480,8 @@ class Image:
         image_pos = [slice(None) for _ in range(array.ndim)]
 
         for index in index_to_add:
-            result_shape[index] += 2
-            image_pos[index] = slice(1, result_shape[index] - 1)
+            result_shape[index] += FRAME_THICKNESS * 2
+            image_pos[index] = slice(FRAME_THICKNESS, result_shape[index] - FRAME_THICKNESS)
 
         data = np.zeros(shape=result_shape, dtype=array.dtype)
         data[tuple(image_pos)] = array

--- a/package/PartSegImage/image.py
+++ b/package/PartSegImage/image.py
@@ -488,7 +488,14 @@ class Image:
         return data
 
     @staticmethod
-    def _calc_index_to_frame(array_axis, important_axis):
+    def calc_index_to_frame(array_axis, important_axis):
+        """
+        calculate in which axis frame should be added
+
+        :param str array_axis: list of image axis
+        :param str important_axis: list of framed axis
+        :return:
+        """
         return [array_axis.index(letter) for letter in important_axis]
 
     def cut_image(
@@ -531,10 +538,10 @@ class Image:
         important_axis = "XY" if self.is_2d else "XYZ"
 
         return self.__class__(
-            self._frame_array(new_image, self._calc_index_to_frame(self.axis_order, important_axis)),
+            self._frame_array(new_image, self.calc_index_to_frame(self.axis_order, important_axis)),
             self._image_spacing,
             None,
-            self._frame_array(new_mask, self._calc_index_to_frame(self.array_axis_order, important_axis)),
+            self._frame_array(new_mask, self.calc_index_to_frame(self.array_axis_order, important_axis)),
             self.default_coloring,
             self.ranges,
             self.labels,

--- a/package/tests/test_PartSeg/test_settings.py
+++ b/package/tests/test_PartSeg/test_settings.py
@@ -7,16 +7,18 @@ import pytest
 
 from PartSeg._roi_analysis.partseg_settings import PartSettings
 from PartSeg._roi_mask.main_window import ChosenComponents
-from PartSeg._roi_mask.stack_settings import StackSettings
+from PartSeg._roi_mask.stack_settings import StackSettings, get_mask
 from PartSeg.common_backend.base_settings import BaseSettings
+from PartSegCore.algorithm_describe_base import ROIExtractionProfile
 from PartSegCore.analysis import analysis_algorithm_dict
-from PartSegCore.analysis.io_utils import create_history_element_from_project
+from PartSegCore.analysis.io_utils import MaskInfo, create_history_element_from_project
 from PartSegCore.analysis.load_functions import LoadProject
 from PartSegCore.analysis.save_functions import SaveProject
-from PartSegCore.io_utils import HistoryProblem
+from PartSegCore.io_utils import HistoryProblem, PointsInfo
 from PartSegCore.mask.history_utils import create_history_element_from_segmentation_tuple
 from PartSegCore.mask.io_functions import LoadStackImage
 from PartSegCore.mask_create import calculate_mask_from_project
+from PartSegCore.segmentation.algorithm_base import SegmentationResult
 
 
 @pytest.fixture
@@ -152,6 +154,24 @@ class TestStackSettings:
         with pytest.raises(HistoryProblem):
             stack_settings.set_project_info(seg2)
 
+    def test_set_segmentation_result(self, stack_settings, stack_segmentation1, stack_image):
+        stack_settings.set_project_info(stack_image)
+        seg = SegmentationResult(roi=stack_segmentation1.roi, parameters=ROIExtractionProfile("test", "test2", {}))
+        stack_settings.set_segmentation_result(seg)
+        assert stack_settings.last_executed_algorithm == "test2"
+        assert np.array_equal(stack_settings.roi, stack_segmentation1.roi)
+
+    def test_selected_components(self, stack_settings, stack_segmentation1):
+        stack_settings.set_project_info(stack_segmentation1)
+        assert stack_settings.chosen_components() == [1, 3]
+        assert stack_settings.component_is_chosen(1)
+        assert not stack_settings.component_is_chosen(2)
+        assert np.array_equal(stack_settings.components_mask(), [0, 1, 0, 1, 0])
+        stack_settings.chosen_components_widget.un_check_all()
+        assert stack_settings.chosen_components() == []
+        stack_settings.chosen_components_widget.check_all()
+        assert stack_settings.chosen_components() == list(range(1, stack_segmentation1.roi.max() + 1))
+
 
 class TestBaseSettings:
     def test_empty_history(self, tmp_path):
@@ -200,8 +220,34 @@ class TestBaseSettings:
         settings.history_redo_clean()
         settings.history_current_element()
 
+    def test_add_point(self, tmp_path, qtbot):
+        settings = BaseSettings(tmp_path)
+        with qtbot.waitSignal(settings.points_changed):
+            settings.points = [1, 2, 3]
+
 
 class TestPartSettings:
+    def test_set_mask_info(self, qtbot, tmp_path, image):
+        settings = PartSettings(tmp_path)
+        settings.image = image
+        mask_info = MaskInfo("", (image.get_channel(0) > 2).astype(np.uint8))
+        with qtbot.wait_signal(settings.mask_changed):
+            settings.set_project_info(mask_info)
+
+    def test_project_info_set(self, qtbot, analysis_segmentation, analysis_segmentation2, tmp_path, image):
+        settings = PartSettings(tmp_path)
+        settings.image = image
+        settings.set_project_info(analysis_segmentation)
+        assert settings.mask is None
+        settings.set_project_info(analysis_segmentation2)
+        assert settings.mask is not None
+        settings.set_project_info(analysis_segmentation)
+        assert settings.mask is None
+        analysis_segmentation3 = dataclasses.replace(analysis_segmentation2, roi=None)
+        settings.set_project_info(analysis_segmentation3)
+        assert settings.mask is not None
+        assert settings.roi is None
+
     def test_get_project_info(self, qtbot, tmp_path, image):
         settings = PartSettings(tmp_path)
         settings.last_executed_algorithm = "aa"
@@ -242,3 +288,35 @@ class TestPartSettings:
         loaded = LoadProject.load([tmp_path / "project.tgz"])
         assert np.all(loaded.roi == result2.roi)
         assert len(loaded.history) == 1
+
+
+@pytest.mark.parametrize("Settings", [PartSettings, StackSettings])
+def test_set_project_info(Settings, qtbot, tmp_path, image):
+    settings = Settings(tmp_path)
+    settings.points = [1, 2, 3]
+    assert settings.points == [1, 2, 3]
+    settings.image = image
+    assert settings.points is None
+    settings.set_project_info(PointsInfo("a", np.arange(3)))
+    assert np.all(settings.points == [0, 1, 2])
+
+
+def test_get_mask(stack_segmentation1):
+    res1 = get_mask(stack_segmentation1.roi, mask=None, selected=[1, 3])
+    assert isinstance(res1, np.ndarray)
+    assert set(np.unique(res1)) == {0, 1}
+    assert set(stack_segmentation1.roi[res1 > 0]) == {0, 2, 4}
+    mask = np.ones(stack_segmentation1.roi.shape, dtype=np.uint8)
+    res2 = get_mask(stack_segmentation1.roi, mask=mask, selected=[1, 3])
+    assert set(np.unique(res2)) == {0, 1}
+    assert np.array_equal(res1, res2)
+    res3 = get_mask(stack_segmentation1.roi, mask=res1, selected=[1, 2])
+    assert set(stack_segmentation1.roi[res3 > 0]) == {0, 4}
+    assert set(np.unique(res3)) == {0, 1}
+    res4 = get_mask(stack_segmentation1.roi, mask=None, selected=[1])
+    assert np.array_equal(res4, stack_segmentation1.roi != 1)
+
+    assert get_mask(stack_segmentation1.roi, mask=None, selected=[]) is None
+    assert get_mask(None, mask=None, selected=[1, 2]) is None
+    assert np.array_equal(get_mask(None, mask=res4, selected=[1, 2]), res4)
+    assert np.array_equal(get_mask(stack_segmentation1.roi, mask=res4, selected=[]), res4)

--- a/package/tests/test_PartSegImage/test_image.py
+++ b/package/tests/test_PartSegImage/test_image.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from PartSegImage import Image, ImageWriter, TiffImageReader
+from PartSegImage.image import FRAME_THICKNESS
 
 
 class TestImageBase:
@@ -294,10 +295,15 @@ class TestImageBase:
         image.set_mask(np.zeros((1, 10, 20, 30), np.uint8), "TZYX")
         im = image.cut_image(mask == 1, replace_mask=False)
         assert np.all(im.mask == 0)
-        assert im.shape == self.image_shape((1, 8, 9, 28, 3), axes="TZYXC")
+        assert im.shape == self.image_shape((1, 10, 11, 30, 3), axes="TZYXC")
         im = image.cut_image(mask == 2, replace_mask=True)
-        assert np.all(im.mask[:, 1:-1, 1:-1, 1:-1] == 1)
-        assert im.shape == self.image_shape((1, 8, 9, 28, 3), axes="TZYXC")
+        assert np.all(
+            im.mask[
+                :, FRAME_THICKNESS:-FRAME_THICKNESS, FRAME_THICKNESS:-FRAME_THICKNESS, FRAME_THICKNESS:-FRAME_THICKNESS
+            ]
+            == 1
+        )
+        assert im.shape == self.image_shape((1, 10, 11, 30, 3), axes="TZYXC")
 
         # Test cutting with list of slices
         points = np.nonzero(mask == 2)
@@ -305,11 +311,11 @@ class TestImageBase:
         upper_bound = np.max(points, axis=1)
         cut_list = [slice(x, y + 1) for x, y in zip(lower_bound, upper_bound)]
         res = image.cut_image(cut_list)
-        shape = [y - x + 1 for x, y in zip(lower_bound, upper_bound)]
+        shape = [y - x + +1 for x, y in zip(lower_bound, upper_bound)]
         shape.insert(image.channel_pos, 3)
-        shape[image.x_pos] += 2
-        shape[image.y_pos] += 2
-        shape[image.stack_pos] += 2
+        shape[image.x_pos] += 2 * FRAME_THICKNESS
+        shape[image.y_pos] += 2 * FRAME_THICKNESS
+        shape[image.stack_pos] += 2 * FRAME_THICKNESS
         assert res.shape == tuple(shape)
 
     def test_get_ranges(self):


### PR DESCRIPTION
This PR adds support of loading points (created for example in napari) to simplify verification of segmentation.

It only supports visualization and cutting points when select Save components in Mask ROI.

Fixed version of #197