### PR TITLE
Update names of AdditionalLayerDescription if missed in SegmentationResult

### DIFF
--- a/package/PartSegCore/segmentation/algorithm_base.py
+++ b/package/PartSegCore/segmentation/algorithm_base.py
@@ -75,13 +75,17 @@ class SegmentationResult:
     def __post_init__(self):
         if "ROI" in self.alternative_representation:
             raise ValueError("alternative_representation field cannot contain field with ROI key")
+        for key, value in self.additional_layers.items():
+            if value.name == "":
+                value.name = key
 
     def __str__(self):  # pragma: no cover
         return (
             f"SegmentationResult(roi=[shape: {self.roi.shape}, dtype: {self.roi.dtype},"
             f" max: {np.max(self.roi)}], parameters={self.parameters},"
             f" additional_layers={list(self.additional_layers.keys())}, info_text={self.info_text},"
-            f" alternative={dict_repr(self.alternative_representation)}, annotation={dict_repr(self.roi_annotation)}"
+            f" alternative={dict_repr(self.alternative_representation)},"
+            f" roi_annotation={dict_repr(self.roi_annotation)}"
         )
 
     def __repr__(self):  # pragma: no cover
@@ -89,7 +93,8 @@ class SegmentationResult:
             f"SegmentationResult(roi=[shape: {self.roi.shape}, dtype: {self.roi.dtype}, "
             f"max: {np.max(self.roi)}], parameters={self.parameters}, "
             f"additional_layers={list(self.additional_layers.keys())}, info_text={self.info_text},"
-            f" alternative={dict_repr(self.alternative_representation)}, annotation={dict_repr(self.roi_annotation)}"
+            f" alternative={dict_repr(self.alternative_representation)},"
+            f" roi_annotation={dict_repr(self.roi_annotation)}"
         )
 
 

--- a/package/tests/test_PartSegCore/segmentation/test_algorithm_base.py
+++ b/package/tests/test_PartSegCore/segmentation/test_algorithm_base.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from PartSegCore.algorithm_describe_base import ROIExtractionProfile
+from PartSegCore.segmentation.algorithm_base import AdditionalLayerDescription, SegmentationResult
+
+
+class TestSegmentationResult:
+    def test_update_alternative_names(self):
+        res = SegmentationResult(
+            roi=np.zeros((10, 10), dtype=np.uint8),
+            parameters=ROIExtractionProfile("test", "test", {}),
+            additional_layers={
+                "test1": AdditionalLayerDescription(np.zeros((10, 10), dtype=np.uint8), "image", "aa"),
+                "test2": AdditionalLayerDescription(np.zeros((10, 10), dtype=np.uint8), "image", ""),
+            },
+        )
+        assert res.additional_layers["test1"].name == "aa"
+        assert res.additional_layers["test2"].name == "test2"


### PR DESCRIPTION
set name for `AdditionalLayerDescription` is not set to the key of `SegmentationResult.additional_layers`