### PR TITLE
Add visibility flag to remove listing from napari hub

### DIFF
--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -1,0 +1,1 @@
+visibility: disabled


### PR DESCRIPTION
This change would allow napari hub to ignore this as a plugin and remove it from both home page and plugin page in napari hub