### PR TITLE
perf: Use faster calc bound function

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -31,3 +31,8 @@ exclude **/.coverage
 exclude .azure-pipelines/**
 exclude dist/*
 exclude .mdlrc
+exclude examples/**
+recursive-include package *.pyi
+exclude dist/**
+exclude dist/**.swp
+exclude cliff.toml

--- a/examples/call_simple_threshold.py
+++ b/examples/call_simple_threshold.py
@@ -1,0 +1,16 @@
+from PartSegCore.io_utils import load_metadata_base
+from PartSegCore.segmentation.segmentation_algorithm import ThresholdPreview
+from PartSegImage import GenericImageReader
+
+file_path = "/home/czaki/Dokumenty/smFish/smFISH_7_001_with_points/test.obsep"
+
+profile_str = '{"__SegmentationProfile__": true, "name": "", "algorithm": "Only Threshold", "values": {"channel": 1, "noise_filtering": {"name": "Gauss", "values": {"dimension_type": {"__Enum__": true, "__subtype__": "PartSegCore.segmentation.noise_filtering.DimensionType", "value": 1}, "radius": 1.0}}, "threshold": 300}}'
+profile = load_metadata_base(profile_str)
+
+image = GenericImageReader.read_image(file_path)
+
+algorithm = ThresholdPreview()
+algorithm.set_image(image)
+algorithm.set_parameters(**profile.values)
+
+res = algorithm.calculation_run(lambda x, y: x)

--- a/package/PartSegCore/roi_info.py
+++ b/package/PartSegCore/roi_info.py
@@ -1,9 +1,9 @@
-from collections import defaultdict
 from typing import Any, Dict, List, NamedTuple, Optional
 
 import numpy as np
 
 from PartSegCore.utils import numpy_repr
+from PartSegCore_compiled_backend.utils import calc_bounds
 from PartSegImage.image import Image, minimal_dtype
 
 
@@ -84,14 +84,9 @@ class ROIInfo:
         :return: mapping component number to bounding box
         :rtype: Dict[int, BoundInfo]
         """
-        bound_info = {}
-        points = np.nonzero(roi)
-        comp_num = roi[points]
-        point_dict = defaultdict(list)
-        for num, point in zip(comp_num, np.transpose(points)):
-            point_dict[num].append(point)
-        for num, points_for_num in point_dict.items():
-            lower = np.min(points_for_num, 0)
-            upper = np.max(points_for_num, 0)
-            bound_info[num] = BoundInfo(lower=lower, upper=upper)
-        return bound_info
+        min_bounds, max_bounds = calc_bounds(roi)
+        return {
+            num: BoundInfo(lower=lower, upper=upper)
+            for num, (lower, upper) in enumerate(zip(min_bounds, max_bounds))
+            if num != 0 and upper[0] != -1
+        }

--- a/package/PartSegCore/roi_info.py
+++ b/package/PartSegCore/roi_info.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import Any, Dict, List, NamedTuple, Optional
 
 import numpy as np
@@ -84,9 +85,22 @@ class ROIInfo:
         :return: mapping component number to bounding box
         :rtype: Dict[int, BoundInfo]
         """
-        min_bounds, max_bounds = calc_bounds(roi)
-        return {
-            num: BoundInfo(lower=lower, upper=upper)
-            for num, (lower, upper) in enumerate(zip(min_bounds, max_bounds))
-            if num != 0 and upper[0] != -1
-        }
+        try:
+            min_bounds, max_bounds = calc_bounds(roi)
+            return {
+                num: BoundInfo(lower=lower, upper=upper)
+                for num, (lower, upper) in enumerate(zip(min_bounds, max_bounds))
+                if num != 0 and upper[0] != -1
+            }
+        except KeyError:
+            bound_info = {}
+            points = np.nonzero(roi)
+            comp_num = roi[points]
+            point_dict = defaultdict(list)
+            for num, point in zip(comp_num, np.transpose(points)):
+                point_dict[num].append(point)
+            for num, points_for_num in point_dict.items():
+                lower = np.min(points_for_num, 0)
+                upper = np.max(points_for_num, 0)
+                bound_info[num] = BoundInfo(lower=lower, upper=upper)
+            return bound_info

--- a/package/PartSegCore/segmentation/segmentation_algorithm.py
+++ b/package/PartSegCore/segmentation/segmentation_algorithm.py
@@ -59,17 +59,26 @@ class ThresholdPreview(StackAlgorithm):
 
     def calculation_run(self, report_fun) -> ROIExtractionResult:
         image = self.get_noise_filtered_channel(self.new_parameters["channel"], self.new_parameters["noise_filtering"])
+        report_fun("threshold", 0)
         res = (image > self.new_parameters["threshold"]).astype(np.uint8)
+        report_fun("mask", 1)
         if self.mask is not None:
             res[self.mask == 0] = 0
-        return ROIExtractionResult(
+        report_fun("result", 2)
+        val = ROIExtractionResult(
             roi=res,
             parameters=self.get_segmentation_profile(),
             additional_layers={"denoised image": AdditionalLayerDescription(layer_type="image", data=image)},
         )
+        report_fun("return", 4)
+        return val
 
     def get_info_text(self):
         return ""
+
+    @staticmethod
+    def get_steps_num():
+        return 3
 
 
 class BaseThresholdAlgorithm(StackAlgorithm, ABC):

--- a/requirements/requirements_pyinstaller.txt
+++ b/requirements/requirements_pyinstaller.txt
@@ -162,7 +162,7 @@ parso==0.8.2
     # via jedi
 partd==1.2.0
     # via dask
-partsegcore-compiled-backend==0.12.0a5
+partsegcore-compiled-backend==0.13.11
     # via -r requirements_pyinstaller.in
 partsegdata==0.10.0
     # via -r requirements_pyinstaller.in

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    PartSegCore_compiled_backend>=0.12.0a0
+    PartSegCore_compiled_backend>=0.13.11
     PartSegData==0.10.0
     PyOpenGL-accelerate>=3.1.5
     QtPy>=1.7.0


### PR DESCRIPTION
In this PR there is a switch to cython backend for calculating the bounding box for ROI. 