### PR TITLE
feat: Add modal dialog for search ROI components

### DIFF
--- a/package/PartSeg/_roi_analysis/image_view.py
+++ b/package/PartSeg/_roi_analysis/image_view.py
@@ -101,7 +101,7 @@ class ResultImageView(ImageView):
         self.roi_alternative_select.blockSignals(block)
 
     def resizeEvent(self, event: QResizeEvent):
-        if event.size().width() > 700 and not self._channel_control_top:
+        if event.size().width() > 800 and not self._channel_control_top:
             w = self.btn_layout2.takeAt(0).widget()
             channel_control_index = self.btn_layout.indexOf(self.search_roi_btn) + 1
             self.btn_layout.takeAt(channel_control_index)
@@ -110,7 +110,7 @@ class ResultImageView(ImageView):
             select = self.btn_layout2.takeAt(self.btn_layout2.indexOf(self.roi_alternative_select)).widget()
             self.btn_layout.insertWidget(channel_control_index + 1, select)
             self._channel_control_top = True
-        elif event.size().width() <= 700 and self._channel_control_top:
+        elif event.size().width() <= 800 and self._channel_control_top:
             channel_control_index = self.btn_layout.indexOf(self.channel_control)
             w = self.btn_layout.takeAt(channel_control_index).widget()
             self.btn_layout.insertStretch(channel_control_index, 1)

--- a/package/PartSeg/_roi_mask/image_view.py
+++ b/package/PartSeg/_roi_mask/image_view.py
@@ -1,6 +1,3 @@
-from typing import List
-
-from napari.layers import Layer
 from vispy.app import MouseEvent
 
 from ..common_gui.channel_control import ChannelProperty
@@ -15,7 +12,6 @@ class StackImageView(ImageView):
     def __init__(self, settings, channel_property: ChannelProperty, name: str):
         super().__init__(settings, channel_property, name)
         self.viewer_widget.canvas.events.mouse_press.connect(self.component_click)
-        self.additional_layers: List[Layer] = []
         # self.image_area.pixmap.click_signal.connect(self.component_click)
 
     def refresh_selected(self):
@@ -24,42 +20,6 @@ class StackImageView(ImageView):
             == LabelEnum.Show_selected
         ):
             self.update_roi_labeling()
-
-    def component_unmark(self, _num):
-        if hasattr(self.viewer.layers, "selection"):
-            self.viewer.layers.selection.clear()
-            for el in self.additional_layers:
-                self.viewer.layers.selection.add(el)
-        else:
-            self.viewer.layers.unselect_all()
-            for el in self.additional_layers:
-                el.selected = True
-        self.viewer.layers.remove_selected()
-        self.additional_layers = []
-
-    def component_mark(self, num):
-        self.component_unmark(num)
-
-        for image_info in self.image_info.values():
-            bound_info = image_info.roi_info.bound_info.get(num, None)
-            if bound_info is None:
-                continue
-            # TODO think about marking on bright background
-            slices = bound_info.get_slices()
-            slices[image_info.image.stack_pos] = slice(None)
-            component_mark = image_info.roi_info.roi[tuple(slices)] == num
-            translate_grid = image_info.roi.translate_grid + (bound_info.lower) * image_info.roi.scale
-            translate_grid[image_info.image.stack_pos] = 0
-            self.additional_layers.append(
-                self.viewer.add_image(
-                    component_mark,
-                    scale=image_info.roi.scale,
-                    blending="additive",
-                    colormap="gray",
-                    opacity=0.5,
-                )
-            )
-            self.additional_layers[-1].translate_grid = translate_grid
 
     def component_click(self, _event: MouseEvent):
         cords = self._coordinates()

--- a/package/PartSeg/common_gui/custom_buttons.py
+++ b/package/PartSeg/common_gui/custom_buttons.py
@@ -1,0 +1,22 @@
+import qtawesome as qta
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QPushButton
+
+from PartSeg.common_backend.base_settings import BaseSettings
+
+
+class QtViewerPushButton(QPushButton):
+    def __init__(self, icon: str, settings: BaseSettings):
+        super().__init__(qta.icon(icon), "")
+        self.settings = settings
+        settings.theme_changed.connect(self._theme_changed)
+        self._theme_changed()
+
+    def _theme_changed(self):
+        color = self.settings.theme.text
+        self.setIcon(qta.icon("fa5s.search", color=QColor(*color.as_rgb_tuple())))
+
+
+class SearchROIButton(QtViewerPushButton):
+    def __init__(self, settings: BaseSettings):
+        super().__init__("fa5s.search", settings)

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -8,7 +8,6 @@ from typing import Dict, List, MutableMapping, Optional, Tuple, Union
 
 import napari
 import numpy as np
-import qtawesome as qta
 from napari.components import ViewerModel as Viewer
 from napari.layers import Layer, Points
 from napari.layers.image import Image as NapariImage
@@ -17,8 +16,7 @@ from napari.qt import QtStateButton, QtViewer
 from napari.qt.threading import thread_worker
 from packaging.version import parse as parse_version
 from qtpy.QtCore import QEvent, QPoint, Qt, QTimer, Signal
-from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QMenu, QPushButton, QSpinBox, QToolTip, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QMenu, QSpinBox, QToolTip, QVBoxLayout, QWidget
 from superqt import QEnumComboBox, ensure_main_thread
 from vispy.color import Color, Colormap
 from vispy.geometry.rect import Rect
@@ -33,6 +31,7 @@ from PartSegImage import Image
 from ..common_backend.base_settings import BaseSettings
 from .advanced_tabs import RENDERING_LIST, RENDERING_MODE_NAME
 from .channel_control import ChannelProperty, ColorComboBoxGroup
+from .custom_buttons import SearchROIButton
 from .qt_modal import QtPopup
 
 try:
@@ -145,7 +144,8 @@ class ImageView(QWidget):
         self.points_view_button = QtViewerPushButton(
             self.viewer, "new_points", "Show points", self.toggle_points_visibility
         )
-        self.search_roi_btn = SearchROIButton(self)
+        self.search_roi_btn = SearchROIButton(self.settings)
+        self.search_roi_btn.setToolTip("Search component")
         # self.search_roi_btn.setDisabled(True)
         self.search_roi_btn.clicked.connect(self._search_component)
         self.roll_dim_button = QtViewerPushButton(self.viewer, "roll", "Roll dimension", self._rotate_dim)
@@ -939,18 +939,6 @@ class ImageParameters:
     colormaps: List[Colormap]
     scaling: Tuple[Union[float, int]]
     layers: int = 0
-
-
-class SearchROIButton(QPushButton):
-    def __init__(self, image_view: ImageView):
-        super().__init__(qta.icon("fa5s.search"), "")
-        self.image_view = image_view
-        image_view.settings.theme_changed.connect(self._theme_changed)
-        self._theme_changed()
-
-    def _theme_changed(self):
-        color = self.image_view.settings.theme.text
-        self.setIcon(qta.icon("fa5s.search", color=QColor(*color.as_rgb_tuple())))
 
 
 def _prepare_layers(image: Image, param: ImageParameters, replace: bool) -> Tuple[ImageInfo, bool]:

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -856,8 +856,8 @@ class ImageView(QWidget):
             bound_info = image_info.roi_info.bound_info.get(num, None)
             if bound_info is None:
                 continue
-            lower_bound_list.append(image_info.roi._data_to_world(bound_info.lower))
-            upper_bound_list.append(image_info.roi._data_to_world(bound_info.upper))
+            lower_bound_list.append(image_info.roi._data_to_world(bound_info.lower))  # pylint: disable=W0212
+            upper_bound_list.append(image_info.roi._data_to_world(bound_info.upper))  # pylint: disable=W0212
 
         if not lower_bound_list:
             return

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -856,8 +856,8 @@ class ImageView(QWidget):
                 self.viewer.dims.set_point(i, point[i])
 
     @staticmethod
-    def _data_to_world(layer: Layer, cords):  # pylint: disable=W0212
-        return layer._transforms[1:3].simplified(cords)
+    def _data_to_world(layer: Layer, cords):
+        return layer._transforms[1:3].simplified(cords)  # pylint: disable=W0212
 
     def _bounding_box(self, num) -> Optional[Tuple[np.ndarray, np.ndarray]]:
         lower_bound_list = []
@@ -866,8 +866,8 @@ class ImageView(QWidget):
             bound_info = image_info.roi_info.bound_info.get(num, None)
             if bound_info is None:
                 continue
-            lower_bound_list.append(self._data_to_world(image_info.roi, bound_info.lower))  # pylint: disable=W0212
-            upper_bound_list.append(self._data_to_world(image_info.roi, bound_info.upper))  # pylint: disable=W0212
+            lower_bound_list.append(self._data_to_world(image_info.roi, bound_info.lower))
+            upper_bound_list.append(self._data_to_world(image_info.roi, bound_info.upper))
 
         if not lower_bound_list:
             return

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -855,7 +855,8 @@ class ImageView(QWidget):
             if not (lower_bound[i] <= current_point[i] <= upper_bound[i]):
                 self.viewer.dims.set_point(i, point[i])
 
-    def _data_to_world(self, layer: Layer, cords):
+    @staticmethod
+    def _data_to_world(layer: Layer, cords):  # pylint: disable=W0212
         return layer._transforms[1:3].simplified(cords)
 
     def _bounding_box(self, num) -> Optional[Tuple[np.ndarray, np.ndarray]]:

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -422,16 +422,21 @@ class ImageView(QWidget):
             if image_info.roi is None:
                 continue
             roi = image_info.roi_info.alternative.get(self.roi_alternative_selection, image_info.roi_info.roi)
-            if self.settings.get_from_profile(f"{self.name}.image_state.only_border", True):
-
+            border_thick = self.settings.get_from_profile(f"{self.name}.image_state.border_thick", 1) == 1
+            only_border = self.settings.get_from_profile(f"{self.name}.image_state.only_border", True)
+            if only_border and border_thick != 1:
                 data = calculate_borders(
                     roi.transpose(ORDER_DICT[self._current_order]),
                     self.settings.get_from_profile(f"{self.name}.image_state.border_thick", 1) // 2,
                     self.viewer.dims.ndisplay == 2,
                 ).transpose(np.argsort(ORDER_DICT[self._current_order]))
                 image_info.roi.data = data
+                image_info.roi.metadata["border_thick"] = border_thick
             else:
-                image_info.roi.data = roi
+                if image_info.roi.metadata.get("border_thick", 1) != 1:
+                    image_info.roi.data = roi
+                image_info.roi.metadata["border_thick"] = 1
+                image_info.roi.contour = only_border
 
     @ensure_main_thread
     def update_rendering(self):

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -794,10 +794,14 @@ class ImageView(QWidget):
             size = u_bound - l_bound
             rect.size = tuple(np.max([rect.size, size * 1.2], axis=0))
             pos = rect.pos
-            if rect.left > l_bound[0] or rect.right < u_bound[0]:
+            if rect.left > l_bound[0]:
                 pos = l_bound[0], pos[1]
-            if rect.top > l_bound[1] or rect.bottom < u_bound[1]:
+            if rect.right < u_bound[0]:
+                pos = pos[0] + u_bound[0] - rect.right, pos[1]
+            if rect.bottom > l_bound[1]:
                 pos = pos[0], l_bound[1]
+            if rect.top < u_bound[1]:
+                pos = pos[0], pos[1] + (u_bound[1] - rect.top)
             rect.pos = pos
             self.viewer_widget.view.camera.set_state({"rect": rect})
 

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -136,7 +136,7 @@ class ImageView(QWidget):
             self.viewer, "new_points", "Show points", self.toggle_points_visibility
         )
         self.search_roi_btn = SearchROIButton(self)
-        self.search_roi_btn.setHidden(True)
+        self.search_roi_btn.setDisabled(True)
         self.roll_dim_button = QtViewerPushButton(self.viewer, "roll", "Roll dimension", self._rotate_dim)
         self.roll_dim_button.setContextMenuPolicy(Qt.CustomContextMenu)
         self.roll_dim_button.customContextMenuRequested.connect(self._dim_order_menu)
@@ -372,7 +372,9 @@ class ImageView(QWidget):
         image_info.roi_count = max(roi_info.bound_info) if roi_info.bound_info else 0
 
         if roi_info.roi is None:
+            self.search_roi_btn.setDisabled(True)
             return
+        self.search_roi_btn.setDisabled(False)
 
         self.add_roi_layer(image_info)
         image_info.roi.color = self.get_roi_view_parameters(image_info)

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -855,6 +855,9 @@ class ImageView(QWidget):
             if not (lower_bound[i] <= current_point[i] <= upper_bound[i]):
                 self.viewer.dims.set_point(i, point[i])
 
+    def _data_to_world(self, layer: Layer, cords):
+        return layer._transforms[1:3].simplified(cords)
+
     def _bounding_box(self, num) -> Optional[Tuple[np.ndarray, np.ndarray]]:
         lower_bound_list = []
         upper_bound_list = []
@@ -862,8 +865,8 @@ class ImageView(QWidget):
             bound_info = image_info.roi_info.bound_info.get(num, None)
             if bound_info is None:
                 continue
-            lower_bound_list.append(image_info.roi._data_to_world(bound_info.lower))  # pylint: disable=W0212
-            upper_bound_list.append(image_info.roi._data_to_world(bound_info.upper))  # pylint: disable=W0212
+            lower_bound_list.append(self._data_to_world(image_info.roi, bound_info.lower))  # pylint: disable=W0212
+            upper_bound_list.append(self._data_to_world(image_info.roi, bound_info.upper))  # pylint: disable=W0212
 
         if not lower_bound_list:
             return

--- a/package/PartSeg/common_gui/qt_modal.py
+++ b/package/PartSeg/common_gui/qt_modal.py
@@ -97,7 +97,7 @@ class QtPopup(QDialog):
                 height = self.sizeHint().height()
                 top += 24 if position == "top" else (window.height() - height - 12)
             elif position in ("left", "right"):
-                height = window.height() * win_ratio
+                height = int(window.height() * win_ratio)
                 height = max(height, min_length)
                 # 22 is for the title bar
                 top += 22 + (window.height() - height) // 2

--- a/package/PartSeg/common_gui/qt_modal.py
+++ b/package/PartSeg/common_gui/qt_modal.py
@@ -49,14 +49,14 @@ class QtPopup(QDialog):
         """Show popup dialog above the mouse cursor position."""
         pos = QCursor().pos()  # mouse position
         szhint = self.sizeHint()
-        pos -= QPoint(szhint.width() / 2, szhint.height() + 14)
+        pos -= QPoint(szhint.width() // 2, szhint.height() + 14)
         self.move(pos)
         self.show()
 
     def show_right_of_mouse(self, *args):
         pos = QCursor().pos()  # mouse position
         szhint = self.sizeHint()
-        pos -= QPoint(-14, szhint.height() / 4)
+        pos -= QPoint(-14, szhint.height() // 4)
         self.move(pos)
         self.show()
 
@@ -91,16 +91,16 @@ class QtPopup(QDialog):
             left = window.pos().x()
             top = window.pos().y()
             if position in ("top", "bottom"):
-                width = window.width() * win_ratio
+                width = int(window.width() * win_ratio)
                 width = max(width, min_length)
-                left += (window.width() - width) / 2
+                left += (window.width() - width) // 2
                 height = self.sizeHint().height()
                 top += 24 if position == "top" else (window.height() - height - 12)
             elif position in ("left", "right"):
                 height = window.height() * win_ratio
                 height = max(height, min_length)
                 # 22 is for the title bar
-                top += 22 + (window.height() - height) / 2
+                top += 22 + (window.height() - height) // 2
                 width = self.sizeHint().width()
                 left += 12 if position == "left" else (window.width() - width - 12)
             else:
@@ -116,14 +116,7 @@ class QtPopup(QDialog):
         # make sure the popup is completely on the screen
         # In Qt ≥5.10 we can use screenAt to know which monitor the mouse is on
 
-        if hasattr(QGuiApplication, "screenAt"):
-            screen_geometry: QRect = QGuiApplication.screenAt(QCursor.pos()).geometry()
-        else:
-            # This widget is deprecated since Qt 5.11
-            from qtpy.QtWidgets import QDesktopWidget
-
-            screen_num = QDesktopWidget().screenNumber(QCursor.pos())
-            screen_geometry = QGuiApplication.screens()[screen_num].geometry()
+        screen_geometry: QRect = QGuiApplication.screenAt(QCursor.pos()).geometry()
 
         left = max(min(screen_geometry.right() - width, left), screen_geometry.left())
         top = max(min(screen_geometry.bottom() - height, top), screen_geometry.top())
@@ -138,5 +131,6 @@ class QtPopup(QDialog):
             Event from the Qt context.
         """
         if event.key() in (Qt.Key_Return, Qt.Key_Enter):
-            return self.close()
+            self.close()
+            return
         super().keyPressEvent(event)

--- a/package/PartSeg/common_gui/qt_modal.py
+++ b/package/PartSeg/common_gui/qt_modal.py
@@ -1,0 +1,142 @@
+"""from napari._qt.dialog.modal """
+from qtpy.QtCore import QPoint, QRect, Qt
+from qtpy.QtGui import QCursor, QGuiApplication
+from qtpy.QtWidgets import QDialog, QFrame, QVBoxLayout
+
+
+class QtPopup(QDialog):
+    """A generic popup window.
+
+    The seemingly extra frame here is to allow rounded corners on a truly
+    transparent background.  New items should be added to QtPopup.frame
+
+    +----------------------------------
+    | Dialog
+    |  +-------------------------------
+    |  | QVBoxLayout
+    |  |  +----------------------------
+    |  |  | QFrame
+    |  |  |  +-------------------------
+    |  |  |  |
+    |  |  |  |  (add a new layout here)
+
+    Parameters
+    ----------
+    parent : qtpy.QtWidgets:QWidget
+        Parent widget of the popup dialog box.
+
+    Attributes
+    ----------
+    frame : qtpy.QtWidgets.QFrame
+        Frame of the popup dialog box.
+    layout : qtpy.QtWidgets.QVBoxLayout
+        Layout of the popup dialog box.
+    """
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setObjectName("QtModalPopup")
+        self.setModal(False)  # if False, then clicking anywhere else closes it
+        self.setWindowFlags(Qt.Popup | Qt.FramelessWindowHint)
+        self.setLayout(QVBoxLayout())
+
+        self.frame = QFrame()
+        self.frame.setObjectName("QtPopupFrame")
+        self.layout().addWidget(self.frame)
+        self.layout().setContentsMargins(0, 0, 0, 0)
+
+    def show_above_mouse(self, *args):
+        """Show popup dialog above the mouse cursor position."""
+        pos = QCursor().pos()  # mouse position
+        szhint = self.sizeHint()
+        pos -= QPoint(szhint.width() / 2, szhint.height() + 14)
+        self.move(pos)
+        self.show()
+
+    def show_right_of_mouse(self, *args):
+        pos = QCursor().pos()  # mouse position
+        szhint = self.sizeHint()
+        pos -= QPoint(-14, szhint.height() / 4)
+        self.move(pos)
+        self.show()
+
+    def move_to(self, position="top", *, win_ratio=0.9, min_length=0):
+        """Move popup to a position relative to the QMainWindow.
+
+        Parameters
+        ----------
+        position : {str, tuple}, optional
+            position in the QMainWindow to show the pop, by default 'top'
+            if str: must be one of {'top', 'bottom', 'left', 'right' }
+            if tuple: must be length 4 with (left, top, width, height)
+        win_ratio : float, optional
+            Fraction of the width (for position = top/bottom) or height (for
+            position = left/right) of the QMainWindow that the popup will
+            occupy.  Only valid when isinstance(position, str).
+            by default 0.9
+        min_length : int, optional
+            Minimum size of the long dimension (width for top/bottom or
+            height fort left/right).
+
+        Raises
+        ------
+        ValueError
+            if position is a string and not one of
+            {'top', 'bottom', 'left', 'right' }
+        """
+        if isinstance(position, str):
+            window = self.parent().window() if self.parent() else None
+            if not window:
+                raise ValueError("Specifying position as a string is only possible if the popup has a parent")
+            left = window.pos().x()
+            top = window.pos().y()
+            if position in ("top", "bottom"):
+                width = window.width() * win_ratio
+                width = max(width, min_length)
+                left += (window.width() - width) / 2
+                height = self.sizeHint().height()
+                top += 24 if position == "top" else (window.height() - height - 12)
+            elif position in ("left", "right"):
+                height = window.height() * win_ratio
+                height = max(height, min_length)
+                # 22 is for the title bar
+                top += 22 + (window.height() - height) / 2
+                width = self.sizeHint().width()
+                left += 12 if position == "left" else (window.width() - width - 12)
+            else:
+                raise ValueError('position must be one of ["top", "left", "bottom", "right"]')
+        elif isinstance(position, (tuple, list)):
+            assert len(position) == 4, "`position` argument must have length 4"
+            left, top, width, height = position
+        else:
+            raise ValueError(f"Wrong type of position {position}")
+
+        # necessary for transparent round corners
+        self.resize(self.sizeHint())
+        # make sure the popup is completely on the screen
+        # In Qt ≥5.10 we can use screenAt to know which monitor the mouse is on
+
+        if hasattr(QGuiApplication, "screenAt"):
+            screen_geometry: QRect = QGuiApplication.screenAt(QCursor.pos()).geometry()
+        else:
+            # This widget is deprecated since Qt 5.11
+            from qtpy.QtWidgets import QDesktopWidget
+
+            screen_num = QDesktopWidget().screenNumber(QCursor.pos())
+            screen_geometry = QGuiApplication.screens()[screen_num].geometry()
+
+        left = max(min(screen_geometry.right() - width, left), screen_geometry.left())
+        top = max(min(screen_geometry.bottom() - height, top), screen_geometry.top())
+        self.setGeometry(left, top, width, height)
+
+    def keyPressEvent(self, event):
+        """Close window on return, else pass event through to super class.
+
+        Parameters
+        ----------
+        event : qtpy.QtCore.QEvent
+            Event from the Qt context.
+        """
+        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+            return self.close()
+        super().keyPressEvent(event)

--- a/package/PartSeg/common_gui/qt_modal.py
+++ b/package/PartSeg/common_gui/qt_modal.py
@@ -106,7 +106,7 @@ class QtPopup(QDialog):
             else:
                 raise ValueError('position must be one of ["top", "left", "bottom", "right"]')
         elif isinstance(position, (tuple, list)):
-            assert len(position) == 4, "`position` argument must have length 4"
+            # assert len(position) == 4, "`position` argument must have length 4"
             left, top, width, height = position
         else:
             raise ValueError(f"Wrong type of position {position}")

--- a/package/tests/test_PartSeg/test_napari_image_view.py
+++ b/package/tests/test_PartSeg/test_napari_image_view.py
@@ -33,6 +33,16 @@ def test_print_dict():
     assert lines[2].startswith("  e")
 
 
+@pytest.fixture
+def image_view(base_settings, image2, qtbot):
+    ch_prop = ChannelProperty(base_settings, "test")
+    view = ImageView(base_settings, channel_property=ch_prop, name="test")
+    qtbot.addWidget(ch_prop)
+    qtbot.addWidget(view)
+    base_settings.image = image2
+    return view
+
+
 class TestImageView:
     def test_constructor(self, base_settings, qtbot):
         ch_prop = ChannelProperty(base_settings, "test")
@@ -70,133 +80,92 @@ class TestImageView:
         view1.viewer.dims.ndisplay = 3
         view2.set_state(view1.get_state())
 
-    def test_order_reset(self, base_settings, image2, qtbot):
-        ch_prop = ChannelProperty(base_settings, "test")
-        view = ImageView(base_settings, channel_property=ch_prop, name="test")
-        qtbot.addWidget(ch_prop)
-        qtbot.addWidget(view)
-        base_settings.image = image2
+    def test_order_reset(self, image_view):
+        image_view._rotate_dim()
+        assert image_view.viewer.dims.order == (0, 2, 1, 3)
+        image_view._reset_view()
+        assert image_view.viewer.dims.order == (0, 1, 2, 3)
 
-        view._rotate_dim()
-        assert view.viewer.dims.order == (0, 2, 1, 3)
-        view._reset_view()
-        assert view.viewer.dims.order == (0, 1, 2, 3)
+    def test_update_rendering(self, base_settings, image_view):
+        base_settings.roi = np.ones(base_settings.image.get_channel(0).shape, dtype=np.uint8)
+        image_view.update_rendering()
 
-    def test_update_rendering(self, base_settings, image2, qtbot):
-        ch_prop = ChannelProperty(base_settings, "test")
-        view = ImageView(base_settings, channel_property=ch_prop, name="test")
-        qtbot.addWidget(ch_prop)
-        qtbot.addWidget(view)
-        base_settings.image = image2
-        base_settings.roi = np.ones(image2.get_channel(0).shape, dtype=np.uint8)
-        view.update_rendering()
-
-    def test_roi_rendering(self, base_settings, image2, qtbot, tmp_path):
-        ch_prop = ChannelProperty(base_settings, "test")
-        view = ImageView(base_settings, channel_property=ch_prop, name="test")
-        qtbot.addWidget(ch_prop)
-        qtbot.addWidget(view)
-        base_settings.image = image2
-        roi = np.ones(image2.get_channel(0).shape, dtype=np.uint8)
+    def test_roi_rendering(self, base_settings, image_view, tmp_path):
+        roi = np.ones(base_settings.image.get_channel(0).shape, dtype=np.uint8)
         roi[..., 1, 1] = 0
         base_settings.roi = roi
-        view.update_roi_border()
-        assert np.any(view.image_info[str(tmp_path / "test2.tiff")].roi.data == 1)
-        view.settings.set_in_profile(f"{view.name}.image_state.only_border", False)
-        view.update_roi_border()
-        assert np.count_nonzero(view.image_info[str(tmp_path / "test2.tiff")].roi.data) == 20 ** 3 - 20
-        base_settings.roi = np.ones(image2.get_channel(0).shape, dtype=np.uint8)
-        assert np.all(view.image_info[str(tmp_path / "test2.tiff")].roi.data)
-        assert np.all(view.image_info[str(tmp_path / "test2.tiff")].roi.scale == (1, 10 ** 6, 10 ** 6, 10 ** 6))
-        image2.set_spacing((10 ** -4,) * 3)
-        view.update_spacing_info()
-        assert np.all(view.image_info[str(tmp_path / "test2.tiff")].roi.scale == (1, 10 ** 5, 10 ** 5, 10 ** 5))
-        view.remove_all_roi()
-        assert view.image_info[str(tmp_path / "test2.tiff")].roi is None
+        image_view.update_roi_border()
+        assert np.any(image_view.image_info[str(tmp_path / "test2.tiff")].roi.data == 1)
+        image_view.settings.set_in_profile(f"{image_view.name}.image_state.only_border", False)
+        image_view.update_roi_border()
+        assert np.count_nonzero(image_view.image_info[str(tmp_path / "test2.tiff")].roi.data) == 20 ** 3 - 20
+        base_settings.roi = np.ones(base_settings.image.get_channel(0).shape, dtype=np.uint8)
+        assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].roi.data)
+        assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].roi.scale == (1, 10 ** 6, 10 ** 6, 10 ** 6))
+        base_settings.image.set_spacing((10 ** -4,) * 3)
+        image_view.update_spacing_info()
+        assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].roi.scale == (1, 10 ** 5, 10 ** 5, 10 ** 5))
+        image_view.remove_all_roi()
+        assert image_view.image_info[str(tmp_path / "test2.tiff")].roi is None
 
-    def test_has_image(self, base_settings, image, image2, qtbot):
-        ch_prop = ChannelProperty(base_settings, "test")
-        view = ImageView(base_settings, channel_property=ch_prop, name="test")
-        qtbot.addWidget(ch_prop)
-        qtbot.addWidget(view)
+    def test_has_image(self, base_settings, image_view, image, image2):
         base_settings.image = image2
-        assert view.has_image(image2)
-        assert not view.has_image(image)
-        view.update_spacing_info()
+        assert image_view.has_image(image2)
+        assert not image_view.has_image(image)
+        image_view.update_spacing_info()
 
-    def test_mask_rendering(self, base_settings, image2, qtbot, tmp_path):
-        ch_prop = ChannelProperty(base_settings, "test")
-        view = ImageView(base_settings, channel_property=ch_prop, name="test")
-        qtbot.addWidget(ch_prop)
-        qtbot.addWidget(view)
-        base_settings.image = image2
-        view.set_mask()
+    def test_mask_rendering(self, base_settings, image_view, qtbot, tmp_path):
+        image_view.set_mask()
         with qtbot.waitSignal(base_settings.mask_changed):
-            base_settings.mask = np.zeros(image2.get_channel(0).shape, dtype=np.uint8)
-        assert np.all(view.image_info[str(tmp_path / "test2.tiff")].mask.data == 1)
+            base_settings.mask = np.zeros(base_settings.image.get_channel(0).shape, dtype=np.uint8)
+        assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].mask.data == 1)
         # double add for test if proper refresh mask is working
         with qtbot.waitSignal(base_settings.mask_changed):
-            base_settings.mask = np.ones(image2.get_channel(0).shape, dtype=np.uint8)
-        assert np.all(view.image_info[str(tmp_path / "test2.tiff")].mask.data == 0)
+            base_settings.mask = np.ones(base_settings.image.get_channel(0).shape, dtype=np.uint8)
+        assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].mask.data == 0)
         base_settings.set_in_profile("mask_presentation_opacity", 0.5)
         # view.update_mask_parameters()
-        assert view.image_info[str(tmp_path / "test2.tiff")].mask.opacity == 0.5
+        assert image_view.image_info[str(tmp_path / "test2.tiff")].mask.opacity == 0.5
         base_settings.set_in_profile("mask_presentation_color", (255, 0, 0))
-        assert np.all(view.image_info[str(tmp_path / "test2.tiff")].mask.color[1] == (1, 0, 0, 1))
+        assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].mask.color[1] == (1, 0, 0, 1))
         base_settings.set_in_profile("mask_presentation_color", (128, 0, 0))
-        assert np.allclose(view.image_info[str(tmp_path / "test2.tiff")].mask.color[1], (128 / 255, 0, 0, 1))
+        assert np.allclose(image_view.image_info[str(tmp_path / "test2.tiff")].mask.color[1], (128 / 255, 0, 0, 1))
 
-        assert not view.image_info[str(tmp_path / "test2.tiff")].mask.visible
-        with qtbot.waitSignal(view.mask_chk.stateChanged):
-            view.mask_chk.setChecked(True)
-        assert view.image_info[str(tmp_path / "test2.tiff")].mask.visible
-        assert np.all(view.image_info[str(tmp_path / "test2.tiff")].mask.scale == (1, 10 ** 6, 10 ** 6, 10 ** 6))
-        image2.set_spacing((10 ** -4,) * 3)
-        view.update_spacing_info()
-        assert np.all(view.image_info[str(tmp_path / "test2.tiff")].mask.scale == (1, 10 ** 5, 10 ** 5, 10 ** 5))
+        assert not image_view.image_info[str(tmp_path / "test2.tiff")].mask.visible
+        with qtbot.waitSignal(image_view.mask_chk.stateChanged):
+            image_view.mask_chk.setChecked(True)
+        assert image_view.image_info[str(tmp_path / "test2.tiff")].mask.visible
+        assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].mask.scale == (1, 10 ** 6, 10 ** 6, 10 ** 6))
+        base_settings.image.set_spacing((10 ** -4,) * 3)
+        image_view.update_spacing_info()
+        assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].mask.scale == (1, 10 ** 5, 10 ** 5, 10 ** 5))
 
-    def test_points_rendering(self, base_settings, image2, qtbot, tmp_path):
-        ch_prop = ChannelProperty(base_settings, "test")
-        view = ImageView(base_settings, channel_property=ch_prop, name="test")
-        qtbot.addWidget(ch_prop)
-        qtbot.addWidget(view)
-        base_settings.image = image2
-        assert view.points_layer is None
+    def test_points_rendering(self, base_settings, image_view, tmp_path):
+        assert image_view.points_layer is None
         base_settings.points = [(0, 5, 5, 5)]
-        assert view.points_layer is not None
-        assert view.points_layer.visible
-        view.toggle_points_visibility()
-        assert not view.points_layer.visible
+        assert image_view.points_layer is not None
+        assert image_view.points_layer.visible
+        image_view.toggle_points_visibility()
+        assert not image_view.points_layer.visible
 
     @pyside_skip
-    def test_dim_menu(self, base_settings, image2, qtbot, monkeypatch):
+    def test_dim_menu(self, base_settings, image_view, monkeypatch):
         called = []
 
         def check_menu(self, point):
             assert len(self.actions()) == len(ORDER_DICT)
             called.append(1)
 
-        ch_prop = ChannelProperty(base_settings, "test")
-        view = ImageView(base_settings, channel_property=ch_prop, name="test")
-        qtbot.addWidget(ch_prop)
-        qtbot.addWidget(view)
-        base_settings.image = image2
-
         monkeypatch.setattr(QMenu, "exec_", check_menu)
-        view._dim_order_menu(QPoint(0, 0))
+        image_view._dim_order_menu(QPoint(0, 0))
         assert called == [1]
 
-    def test_update_alternatives(self, base_settings, image2, qtbot, tmp_path):
-        ch_prop = ChannelProperty(base_settings, "test")
-        view = ImageView(base_settings, channel_property=ch_prop, name="test")
-        qtbot.addWidget(ch_prop)
-        qtbot.addWidget(view)
-        base_settings.image = image2
-        roi = np.ones(image2.get_channel(0).shape, dtype=np.uint8)
+    def test_update_alternatives(self, base_settings, image_view, tmp_path):
+        roi = np.ones(base_settings.image.get_channel(0).shape, dtype=np.uint8)
         roi[..., 1, 1] = 0
         base_settings.roi = ROIInfo(roi, alternative={"test": np.ones(roi.shape, dtype=np.uint8) - roi})
-        view.update_roi_border()
-        assert np.all(view.image_info[str(tmp_path / "test2.tiff")].roi.data == roi)
-        view.roi_alternative_selection = "test"
-        view.update_roi_border()
-        assert np.all(view.image_info[str(tmp_path / "test2.tiff")].roi.data != roi)
+        image_view.update_roi_border()
+        assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].roi.data == roi)
+        image_view.roi_alternative_selection = "test"
+        image_view.update_roi_border()
+        assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].roi.data != roi)


### PR DESCRIPTION
This PR adds the possibility of a searching a single component by its number

![Zrzut ekranu z 2021-11-24 11-09-23](https://user-images.githubusercontent.com/3826210/143218274-76824a23-e969-4821-bb06-0ca0a9c13935.png)

There are two possible modes:

* **Highlight** - highlight selected component, view area is changed only fi component is not visible in the current field of view.,
* **Zoom in** - zoom to the component. Field of view is selected to be filed with the component. 

Currently, not all features work in 3D. 
