### PR TITLE
fix: Hide points button if no points are loaded, hide Mask checkbox if no mask is set

### DIFF
--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -135,6 +135,7 @@ class ImageView(QWidget):
         self.points_view_button = QtViewerPushButton(
             self.viewer, "new_points", "Show points", self.toggle_points_visibility
         )
+        self.points_view_button.setVisible(False)
         self.search_roi_btn = SearchROIButton(self)
         self.search_roi_btn.setHidden(True)
         self.roll_dim_button = QtViewerPushButton(self.viewer, "roll", "Roll dimension", self._rotate_dim)

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -145,8 +145,7 @@ class ImageView(QWidget):
             self.viewer, "new_points", "Show points", self.toggle_points_visibility
         )
         self.points_view_button.setVisible(False)
-        self.search_roi_btn = SearchROIButton(self)
-        self.search_roi_btn.setHidden(True)
+        self.search_roi_btn = SearchROIButton(self.settings)
         self.search_roi_btn.clicked.connect(self._search_component)
         self.roll_dim_button = QtViewerPushButton(self.viewer, "roll", "Roll dimension", self._rotate_dim)
         self.roll_dim_button.setContextMenuPolicy(Qt.CustomContextMenu)

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -142,7 +142,9 @@ class ImageView(QWidget):
         self.roll_dim_button.setContextMenuPolicy(Qt.CustomContextMenu)
         self.roll_dim_button.customContextMenuRequested.connect(self._dim_order_menu)
         self.mask_chk = QCheckBox()
+        self.mask_chk.setVisible(False)
         self.mask_label = QLabel("Mask:")
+        self.mask_label.setVisible(False)
 
         self.btn_layout = QHBoxLayout()
         self.btn_layout.addWidget(self.reset_view_button)
@@ -494,6 +496,7 @@ class ImageView(QWidget):
             image_info.mask = None
 
         if mask is None:
+            self._toggle_mask_chk_visibility()
             return
 
         mask_marker = mask == 0
@@ -503,6 +506,12 @@ class ImageView(QWidget):
         layer.opacity = self.mask_opacity()
         layer.visible = self.mask_chk.isChecked()
         image_info.mask = layer
+        self._toggle_mask_chk_visibility()
+
+    def _toggle_mask_chk_visibility(self):
+        visibility = any(image_info.mask is not None for image_info in self.image_info.values())
+        self.mask_chk.setVisible(visibility)
+        self.mask_label.setVisible(visibility)
 
     def update_mask_parameters(self):
         opacity = self.mask_opacity()
@@ -592,6 +601,7 @@ class ImageView(QWidget):
             self.set_roi()
         if image_info.image.mask is not None:
             self.set_mask()
+        self._toggle_mask_chk_visibility()
         self.image_added.emit()
 
     def add_image(self, image: Optional[Image], replace=False):

--- a/package/tests/test_PartSeg/test_napari_image_view.py
+++ b/package/tests/test_PartSeg/test_napari_image_view.py
@@ -153,23 +153,18 @@ class TestImageView:
         assert np.all(image_view.image_info[str(tmp_path / "test2.tiff")].mask.scale == (1, 10 ** 5, 10 ** 5, 10 ** 5))
 
     @pytest.mark.skipif((platform.system() == "Windows") and CI_BUILD, reason="glBindFramebuffer with no OpenGL")
-    def test_mask_control_visibility(self, base_settings, image2, qtbot, tmp_path):
-        ch_prop = ChannelProperty(base_settings, "test")
-        view = ImageView(base_settings, channel_property=ch_prop, name="test")
-        qtbot.addWidget(ch_prop)
-        qtbot.addWidget(view)
-        base_settings.image = image2
-        view.show()
-        assert not view.mask_chk.isVisible()
-        view.set_mask()
-        assert not view.mask_chk.isVisible()
+    def test_mask_control_visibility(self, base_settings, image_view, qtbot, tmp_path):
+        image_view.show()
+        assert not image_view.mask_chk.isVisible()
+        image_view.set_mask()
+        assert not image_view.mask_chk.isVisible()
         with qtbot.waitSignal(base_settings.mask_changed):
-            base_settings.mask = np.zeros(image2.get_channel(0).shape, dtype=np.uint8)
-        assert view.mask_chk.isVisible()
+            base_settings.mask = np.zeros(base_settings.image.get_channel(0).shape, dtype=np.uint8)
+        assert image_view.mask_chk.isVisible()
         with qtbot.waitSignal(base_settings.mask_changed):
             base_settings.mask = None
-        assert not view.mask_chk.isVisible()
-        view.hide()
+        assert not image_view.mask_chk.isVisible()
+        image_view.hide()
 
     def test_points_rendering(self, base_settings, image_view, tmp_path):
         assert image_view.points_layer is None
@@ -180,19 +175,14 @@ class TestImageView:
         assert not image_view.points_layer.visible
 
     @pytest.mark.skipif((platform.system() == "Windows") and CI_BUILD, reason="glBindFramebuffer with no OpenGL")
-    def test_points_button_visibility(self, base_settings, image2, qtbot, tmp_path):
-        ch_prop = ChannelProperty(base_settings, "test")
-        view = ImageView(base_settings, channel_property=ch_prop, name="test")
-        qtbot.addWidget(ch_prop)
-        qtbot.addWidget(view)
-        base_settings.image = image2
-        view.show()
-        assert not view.points_view_button.isVisible()
+    def test_points_button_visibility(self, base_settings, image_view, qtbot, tmp_path):
+        image_view.show()
+        assert not image_view.points_view_button.isVisible()
         base_settings.points = [(0, 5, 5, 5)]
-        assert view.points_view_button.isVisible()
+        assert image_view.points_view_button.isVisible()
         base_settings.points = None
-        assert not view.points_view_button.isVisible()
-        view.hide()
+        assert not image_view.points_view_button.isVisible()
+        image_view.hide()
 
     @pyside_skip
     def test_dim_menu(self, base_settings, image_view, monkeypatch):

--- a/package/tests/test_PartSeg/test_napari_image_view.py
+++ b/package/tests/test_PartSeg/test_napari_image_view.py
@@ -129,13 +129,9 @@ class TestImageView:
         qtbot.addWidget(ch_prop)
         qtbot.addWidget(view)
         base_settings.image = image2
-        view.show()
-        assert not view.mask_chk.isVisible()
         view.set_mask()
-        assert not view.mask_chk.isVisible()
         with qtbot.waitSignal(base_settings.mask_changed):
             base_settings.mask = np.zeros(image2.get_channel(0).shape, dtype=np.uint8)
-        assert view.mask_chk.isVisible()
         assert np.all(view.image_info[str(tmp_path / "test2.tiff")].mask.data == 1)
         # double add for test if proper refresh mask is working
         with qtbot.waitSignal(base_settings.mask_changed):
@@ -157,7 +153,6 @@ class TestImageView:
         image2.set_spacing((10 ** -4,) * 3)
         view.update_spacing_info()
         assert np.all(view.image_info[str(tmp_path / "test2.tiff")].mask.scale == (1, 10 ** 5, 10 ** 5, 10 ** 5))
-        view.hide()
 
     def test_points_rendering(self, base_settings, image2, qtbot, tmp_path):
         ch_prop = ChannelProperty(base_settings, "test")
@@ -165,16 +160,12 @@ class TestImageView:
         qtbot.addWidget(ch_prop)
         qtbot.addWidget(view)
         base_settings.image = image2
-        view.show()
         assert view.points_layer is None
-        assert not view.points_view_button.isVisible()
         base_settings.points = [(0, 5, 5, 5)]
-        assert view.points_view_button.isVisible()
         assert view.points_layer is not None
         assert view.points_layer.visible
         view.toggle_points_visibility()
         assert not view.points_layer.visible
-        view.hide()
 
     @pyside_skip
     def test_dim_menu(self, base_settings, image2, qtbot, monkeypatch):

--- a/package/tests/test_PartSeg/test_napari_image_view.py
+++ b/package/tests/test_PartSeg/test_napari_image_view.py
@@ -129,9 +129,13 @@ class TestImageView:
         qtbot.addWidget(ch_prop)
         qtbot.addWidget(view)
         base_settings.image = image2
+        view.show()
+        assert not view.mask_chk.isVisible()
         view.set_mask()
+        assert not view.mask_chk.isVisible()
         with qtbot.waitSignal(base_settings.mask_changed):
             base_settings.mask = np.zeros(image2.get_channel(0).shape, dtype=np.uint8)
+        assert view.mask_chk.isVisible()
         assert np.all(view.image_info[str(tmp_path / "test2.tiff")].mask.data == 1)
         # double add for test if proper refresh mask is working
         with qtbot.waitSignal(base_settings.mask_changed):
@@ -153,6 +157,7 @@ class TestImageView:
         image2.set_spacing((10 ** -4,) * 3)
         view.update_spacing_info()
         assert np.all(view.image_info[str(tmp_path / "test2.tiff")].mask.scale == (1, 10 ** 5, 10 ** 5, 10 ** 5))
+        view.hide()
 
     def test_points_rendering(self, base_settings, image2, qtbot, tmp_path):
         ch_prop = ChannelProperty(base_settings, "test")
@@ -160,12 +165,16 @@ class TestImageView:
         qtbot.addWidget(ch_prop)
         qtbot.addWidget(view)
         base_settings.image = image2
+        view.show()
         assert view.points_layer is None
+        assert not view.points_view_button.isVisible()
         base_settings.points = [(0, 5, 5, 5)]
+        assert view.points_view_button.isVisible()
         assert view.points_layer is not None
         assert view.points_layer.visible
         view.toggle_points_visibility()
         assert not view.points_layer.visible
+        view.hide()
 
     @pyside_skip
     def test_dim_menu(self, base_settings, image2, qtbot, monkeypatch):


### PR DESCRIPTION
To keep the interface more clear points toggle button will be hidden if there are no points. 