### PR TITLE
fix: ROI aternative reopresentation 

### DIFF
--- a/package/PartSeg/_roi_analysis/image_view.py
+++ b/package/PartSeg/_roi_analysis/image_view.py
@@ -96,8 +96,12 @@ class ResultImageView(ImageView):
         block = self.roi_alternative_select.signalsBlocked()
         self.roi_alternative_select.blockSignals(True)
         self.roi_alternative_select.clear()
-        self.roi_alternative_select.addItems(["ROI"] + list(alternatives))
-        self.roi_alternative_select.setCurrentText(text)
+        values = ["ROI"] + list(alternatives)
+        self.roi_alternative_select.addItems(values)
+        try:
+            self.roi_alternative_select.setCurrentIndex(values.index(text))
+        except ValueError:
+            pass
         self.roi_alternative_select.blockSignals(block)
 
     def resizeEvent(self, event: QResizeEvent):

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -383,7 +383,7 @@ class ImageView(QWidget):
             return
         else:
             image_info.roi_info = roi_info
-            image_info.roi.data = roi_info.roi
+            image_info.roi.data = roi_info.alternative.get(self.roi_alternative_selection, roi_info.roi)
             image_info.roi.visible = True
             self.search_roi_btn.setDisabled(False)
 


### PR DESCRIPTION
This PR fixes the bug of not saving selected alternatives when setting new ROI from segmentation. 