### PR TITLE
Not use GabrielBB/xvfb-action on non linux systems

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -67,12 +67,23 @@ jobs:
           pip install --upgrade pip
           pip install setuptools tox tox-gh-actions
 
-      - name: Test with tox
+      - name: Test with tox linux
         # run tests using pip install --pre
+        if: runner.os == 'Linux'
         uses: GabrielBB/xvfb-action@v1
         timeout-minutes: 60
         with:
           run: tox -v --pre
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          PYVISTA_OFF_SCREEN: True  # required for opengl on windows
+          NAPARI: None
+
+      - name: Test with tox linux
+        # run tests using pip install --pre
+        if: runner.os != 'Linux'
+        timeout-minutes: 60
+        run: tox -v --pre
         env:
           PLATFORM: ${{ matrix.platform }}
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,15 +72,27 @@ jobs:
       run: |
         python -m pip install -r requirements/requirements_dev.txt tox-gh-actions
 
-    - name: Test with tox
+    - name: Test with tox linux
       # run tests using pip install --pre
+      if: runner.os == 'Linux'
       uses: GabrielBB/xvfb-action@v1
       timeout-minutes: 60
       with:
         run: tox
       env:
+        PLATFORM: ${{ matrix.platform }}
+        PYVISTA_OFF_SCREEN: True  # required for opengl on windows
         NAPARI: None
 
+    - name: Test with tox linux
+      # run tests using pip install --pre
+      if: runner.os != 'Linux'
+      timeout-minutes: 60
+      run: tox
+      env:
+        PLATFORM: ${{ matrix.platform }}
+        PYVISTA_OFF_SCREEN: True  # required for opengl on windows
+        NAPARI: None
 
   test_feature:
     name: PartSeg on ${{ matrix.os }} py ${{ matrix.python_version }}


### PR DESCRIPTION
Because of problems described in https://github.com/GabrielBB/xvfb-action/issues/25 stop using GabrielBB/xvfb-action until the source of segfaults problem will be solved.