### PR TITLE
feat: Make `*.obsep" file possible to load in PartSeg Analysis

### DIFF
--- a/package/PartSegCore/analysis/load_functions.py
+++ b/package/PartSegCore/analysis/load_functions.py
@@ -158,7 +158,7 @@ class LoadProject(LoadBase):
 class LoadStackImage(LoadBase):
     @classmethod
     def get_name(cls):
-        return "Image (*.tif *.tiff *.lsm *.czi *.oib *.oif)"
+        return "Image (*.tif *.tiff *.lsm *.czi *.oib *.oif *.obsep)"
 
     @classmethod
     def get_short_name(cls):


### PR DESCRIPTION
This PR also makes possible to load `*.obsep` file in napari reader plugin.