### PR TITLE
Increase max value in SearchLabel widget

### DIFF
--- a/package/PartSeg/plugins/napari_widgets/search_label_widget.py
+++ b/package/PartSeg/plugins/napari_widgets/search_label_widget.py
@@ -20,7 +20,7 @@ class SearchLabel(Container):
         self.napari_viewer = napari_viewer
         self.search_type = create_widget(annotation=SearchType, label="Search type")
         self.search_type.changed.connect(self._component_num_changed)
-        self.component_selector = SpinBox(name="Label number", min=0, max=2**64 - 1)
+        self.component_selector = SpinBox(name="Label number", min=0, max=2**31 - 1)
         self.component_selector.changed.connect(self._component_num_changed)
         self.labels_layer = create_widget(annotation=Labels, label="ROI", options={})
         self.labels_layer.changed.connect(self._update_roi_info)

--- a/package/PartSeg/plugins/napari_widgets/search_label_widget.py
+++ b/package/PartSeg/plugins/napari_widgets/search_label_widget.py
@@ -20,7 +20,7 @@ class SearchLabel(Container):
         self.napari_viewer = napari_viewer
         self.search_type = create_widget(annotation=SearchType, label="Search type")
         self.search_type.changed.connect(self._component_num_changed)
-        self.component_selector = SpinBox(name="Label number", min=0)
+        self.component_selector = SpinBox(name="Label number", min=0, max=2**64 - 1)
         self.component_selector.changed.connect(self._component_num_changed)
         self.labels_layer = create_widget(annotation=Labels, label="ROI", options={})
         self.labels_layer.changed.connect(self._update_roi_info)


### PR DESCRIPTION
Hi everyone,

Thank you for creating this amazing piece of software!

I noticed that the maximum value for the search label widget is 999. Given that cell labels tend to be much larger than that would it make sense to increase the maximum? I couldn't find a way to make it unbounded but I figured a sensible max would be the largest value uint64 can encode.

What do you think?