### PR TITLE
feat: Allow customize settings directory using the `PARTSEG_SETTINGS_DIR` environment variable

### DIFF
--- a/package/PartSeg/common_backend/base_argparser.py
+++ b/package/PartSeg/common_backend/base_argparser.py
@@ -88,7 +88,8 @@ class CustomParser(argparse.ArgumentParser):
             "--sdir",
             type=proper_path,
             default=[state_store.save_folder],
-            help="path to custom configuration folder",
+            help=f"path to custom configuration folder, if not set then {state_store.save_folder} will be used. "
+            "Could be customized using 'PARTSEG_SETTINGS_DIR' environment variable.",
             nargs=1,
             metavar="path",
         )

--- a/package/PartSegCore/state_store.py
+++ b/package/PartSegCore/state_store.py
@@ -1,3 +1,6 @@
+"""
+Module with default values of application state
+"""
 import os
 
 import appdirs
@@ -12,5 +15,16 @@ check_for_updates = True
 develop = False
 save_suffix = ""
 save_folder = os.path.join(
-    appdirs.user_data_dir(APP_NAME, APP_LAB), str(packaging.version.parse(__version__).base_version)
+    os.environ.get("PARTSEG_SETTINGS_DIR", appdirs.user_data_dir(APP_NAME, APP_LAB)),
+    str(packaging.version.parse(__version__).base_version),
+)
+
+__all__ = (
+    "report_errors",
+    "show_error_dialog",
+    "custom_plugin_load",
+    "check_for_updates",
+    "develop",
+    "save_suffix",
+    "save_folder",
 )


### PR DESCRIPTION
allow using `PARTSEG_SETTINGS_DIR` environment variable to set the default directory with PartSeg settings. 
