### PR TITLE
chore: Add python 3.11 to list of supported versions

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -79,6 +79,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           NAPARI: latest
+          BACKEND: PyQt5
 
       # If something goes wrong, we can open an issue in the repo
       - name: Report Failures

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,10 @@ jobs:
         python_version: ["3.8", "3.9", "3.10"]
         os: ["ubuntu-20.04", "macos-11", "windows-2019"]
         qt_backend: ["PySide2", "PyQt5"]
+        include:
+          - python_version: "3.11"
+            qt_backend: "PyQt5"
+            os: "ubuntu-20.04"
     with:
       test_data: True
       python_version: ${{ matrix.python_version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     rev: v2.2.0
     hooks:
     - id: setup-cfg-fmt
-      args: ["--include-version-classifiers"]
+      args: ["--include-version-classifiers", "--max-py-version", "3.11"]
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.194
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     rev: v2.2.0
     hooks:
     - id: setup-cfg-fmt
-      args: ["--include-version-classifiers", "--max-py-version", "3.10"]
+      args: ["--include-version-classifiers"]
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.194
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ project_urls =
 packages = find:
 install_requires =
     IPython>=7.7.0
-    PartSegCore-compiled-backend>=0.13.11
+    PartSegCore-compiled-backend>=0.13.11,<0.16.0
     PartSegData==0.10.0
     QtAwesome!=1.2.0,>=1.0.3
     QtPy>=1.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Bio-Informatics
     Topic :: Scientific/Engineering :: Image Processing

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 fail_on_no_env = True
 
 [gh-actions:env]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{38,39,310}-{PyQt5, PySide2}-all, py{38,39,310}-{PyQt5,PySide2}-napari_{414,415,416,417,repo}
+envlist = py{38,39,310,311}-{PyQt5, PySide2}-all, py{38,39,310,311}-{PyQt5,PySide2}-napari_{414,415,416,417,repo}
 toxworkdir=/tmp/tox
 
 [gh-actions]
@@ -61,7 +61,7 @@ conda_env=environment.yml
 deps=
     pytest
 
-[testenv:py{38,39,310}-{PyQt5,PySide2}-napari_{414,415,416,417,repo}]
+[testenv:py{38,39,310,311}-{PyQt5,PySide2}-napari_{414,415,416,417,repo}]
 deps =
     {[base]deps}
     414: napari==0.4.14
@@ -73,7 +73,7 @@ commands =
     !repo: python -m pytest -v package/tests/test_PartSeg/test_napari_widgets.py  --no-cov
     repo: python -m pytest --no-cov .
 
-[testenv:py{38,39,310}-PyQt5-coverage]
+[testenv:py{38,39,310,311s}-PyQt5-coverage]
 deps =
     {[testenv]deps}
 commands =


### PR DESCRIPTION
Add python 3.11 to list of supported python, but run test only on `main` and `develop` as there is a need to build `SimpleITK` from the source 