### PR TITLE
bugfix: fix bug with generation of form for model with hidden field

### DIFF
--- a/package/PartSegCore/algorithm_describe_base.py
+++ b/package/PartSegCore/algorithm_describe_base.py
@@ -552,7 +552,8 @@ def _field_to_algorithm_property(name: str, field: "ModelField"):
     user_name = field.field_info.title
     value_range = None
     possible_values = None
-    value_type = field.annotation
+
+    value_type = getattr(field, "annotation", field.type_)
     default_value = field.field_info.default
     help_text = field.field_info.description
     if user_name is None:

--- a/package/PartSegCore/algorithm_describe_base.py
+++ b/package/PartSegCore/algorithm_describe_base.py
@@ -552,7 +552,7 @@ def _field_to_algorithm_property(name: str, field: "ModelField"):
     user_name = field.field_info.title
     value_range = None
     possible_values = None
-    value_type = field.type_
+    value_type = field.annotation
     default_value = field.field_info.default
     help_text = field.field_info.description
     if user_name is None:
@@ -593,6 +593,8 @@ def base_model_to_algorithm_property(obj: typing.Type[BaseModel]) -> typing.List
         res.append(obj.header())
     for name, value in obj.__fields__.items():
         ap = _field_to_algorithm_property(name, value)
+        if value.field_info.extra.get("hidden", False):
+            continue
         pos = len(res)
         if "position" in value.field_info.extra:
             pos = value.field_info.extra["position"]

--- a/package/PartSegCore/mask/io_functions.py
+++ b/package/PartSegCore/mask/io_functions.py
@@ -119,7 +119,7 @@ class SaveROIOptions(BaseModel):
         description="When loading data in ROI analysis, if not checked"
         " then data outside ROI will be replaced with zeros.",
     )
-    spacing: typing.List[float] = Field((10**-6, 10**-6, 10**-6), hidden=True)
+    spacing: typing.List[float] = Field([10**-6, 10**-6, 10**-6], hidden=True)
 
 
 def _save_mask_roi(project: MaskProjectTuple, tar_file: tarfile.TarFile, parameters: SaveROIOptions):

--- a/package/tests/test_PartSegCore/test_algorithm_describe_base.py
+++ b/package/tests/test_PartSegCore/test_algorithm_describe_base.py
@@ -267,6 +267,16 @@ def test_base_model_to_algorithm_property_hline():
     assert isinstance(fields[2], str)
 
 
+def test_hidden_field():
+    class Model(BaseModel):
+        field1: int = Field(1, hidden=True)
+        field2: int = 1
+
+    fields = base_model_to_algorithm_property(Model)
+    assert len(fields) == 1
+    assert fields[0].name == "field2"
+
+
 class TestAlgorithmDescribeBase:
     def test_old_style_algorithm(self):
         class SampleAlgorithm(AlgorithmDescribeBase):


### PR DESCRIPTION
This PR fixed bug that during the generation of the form, the hidden attribute was ignored. 