### PR TITLE
refactor: Remove `pkg_resources` usage as it is deprecated

### DIFF
--- a/launcher.spec
+++ b/launcher.spec
@@ -123,10 +123,10 @@ napari_base_path = os.path.dirname(os.path.dirname(napari.__file__))
 napari_resource_dest_path = os.path.relpath(os.path.dirname(napari_resource_path), napari_base_path)
 
 packages = itertools.chain(
-    pkg_resources.iter_entry_points("PartSeg.plugins"),
-    pkg_resources.iter_entry_points("partseg.plugins"),
-    pkg_resources.iter_entry_points("PartSegCore.plugins"),
-    pkg_resources.iter_entry_points("partsegcore.plugins"),
+    importlib.metadata.entry_points().get("PartSeg.plugins", []),
+    importlib.metadata.entry_points().get("partseg.plugins", []),
+    importlib.metadata.entry_points().get("PartSegCore.plugins", []),
+    importlib.metadata.entry_points().get("partsegcore.plugins", []),
 )
 
 plugins_data = []

--- a/package/PartSeg/plugins/__init__.py
+++ b/package/PartSeg/plugins/__init__.py
@@ -5,8 +5,7 @@ import os
 import pkgutil
 import sys
 import typing
-
-import pkg_resources
+from importlib.metadata import entry_points
 
 import PartSegCore.plugins
 
@@ -47,8 +46,8 @@ def get_plugins():
     else:
         packages = pkgutil.iter_modules(__path__, f"{__name__}.")
     packages2 = itertools.chain(
-        pkg_resources.iter_entry_points("PartSeg.plugins"),
-        pkg_resources.iter_entry_points("partseg.plugins"),
+        entry_points().get("PartSeg.plugins", []),
+        entry_points().get("partseg.plugins", []),
     )
     return [importlib.import_module(el.name) for el in packages] + [el.load() for el in packages2]
 

--- a/package/PartSegCore/plugins/__init__.py
+++ b/package/PartSegCore/plugins/__init__.py
@@ -2,15 +2,14 @@ import importlib
 import itertools
 import pkgutil
 import typing
-
-import pkg_resources
+from importlib.metadata import entry_points
 
 
 def get_plugins():
     packages = pkgutil.iter_modules(__path__, f"{__name__}.")
     packages2 = itertools.chain(
-        pkg_resources.iter_entry_points("PartSegCore.plugins"),
-        pkg_resources.iter_entry_points("partsegcore.plugins"),
+        entry_points().get("PartSegCore.plugins", []),
+        entry_points().get("partsegcore.plugins", []),
     )
     return [importlib.import_module(el.name) for el in packages] + [el.load() for el in packages2]
 


### PR DESCRIPTION
replace `pkg_resources.iter_entry_points` with importlib.metadata.entry_points