### PR TITLE
fix: Bump os version for main tests workflow.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,10 +77,10 @@ jobs:
         qt_backend: ["PySide2", "PyQt5"]
         include:
           - python_version: "3.9"
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             qt_backend: "PySide6"
           - python_version: "3.9"
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             qt_backend: "PyQt6"
     with:
       test_data: True


### PR DESCRIPTION
followup to #977
change from ubuntu 20.04 to 22.04 