### PR TITLE
fix: importing plugins in bundle keeping proper module names 

### DIFF
--- a/launcher.spec
+++ b/launcher.spec
@@ -81,6 +81,7 @@ hiddenimports = (
         "numpy.random.entropy",
         "PartSegCore.register",
         "PartSegCore.channel_class",
+        "nme",
         "defusedxml.cElementTree",
         "vispy.app.backends._pyqt5",
         "scipy.spatial.transform._rotation_groups",

--- a/package/PartSeg/plugins/__init__.py
+++ b/package/PartSeg/plugins/__init__.py
@@ -1,5 +1,6 @@
 import contextlib
 import importlib
+import importlib.util
 import itertools
 import os
 import pkgutil
@@ -24,10 +25,12 @@ def register_napari_plugins():  # pragma: no cover
 def get_plugins():
     if getattr(sys, "frozen", False):
         new_path = [os.path.join(os.path.dirname(os.path.dirname(__path__[0])), "plugins")]
-        packages = pkgutil.iter_modules(new_path, "plugins.")
+        sys.path.append(new_path[0])
+        packages = pkgutil.iter_modules(new_path)
         register_napari_plugins()
     else:
-        packages = pkgutil.iter_modules(__path__, f"{__name__}.")
+        sys.path.append(os.path.dirname(__file__))
+        packages = list(pkgutil.iter_modules(__path__))
     packages2 = itertools.chain(
         entry_points().get("PartSeg.plugins", []),
         entry_points().get("partseg.plugins", []),

--- a/package/PartSeg/plugins/__init__.py
+++ b/package/PartSeg/plugins/__init__.py
@@ -1,6 +1,5 @@
 import contextlib
 import importlib
-import importlib.util
 import itertools
 import os
 import pkgutil
@@ -23,7 +22,7 @@ def register_napari_plugins():  # pragma: no cover
 
 
 def get_plugins():
-    if getattr(sys, "frozen", False):
+    if getattr(sys, "frozen", False):  # pragma: no cover
         new_path = [os.path.join(os.path.dirname(os.path.dirname(__path__[0])), "plugins")]
         sys.path.append(new_path[0])
         packages = pkgutil.iter_modules(new_path)


### PR DESCRIPTION
import plugin as `plugin_name` not `plugins.plugin_name`

fix PARTSEG-SV 
fix PARTSEG-ST
fix PARTSEG-SS
fix PARTSEG-SR
fix PARTSEG-SV