### PR TITLE
fix: Fix napari repo workflow

### DIFF
--- a/.github/workflows/test_napari_repo.yml
+++ b/.github/workflows/test_napari_repo.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ ubuntu-20.04 ]
+        platform: [ ubuntu-22.04 ]
         python: ['3.8', '3.9' , '3.10']
         napari_version: [repo]
     steps:
@@ -61,7 +61,7 @@ jobs:
 
       - name: Test with tox
         # run tests using pip install --pre
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         timeout-minutes: 60
         with:
           run: tox


### PR DESCRIPTION
Bump system to Ubuntu 22.04 for compatibility with `PyQt6==6.5.1`

Change to `aganders3/headless-gui` 

closes #984