### PR TITLE
fix: Fix range threshold selection of algorithms

### DIFF
--- a/package/PartSegCore/algorithm_describe_base.py
+++ b/package/PartSegCore/algorithm_describe_base.py
@@ -9,14 +9,12 @@ from functools import wraps
 from local_migrator import REGISTER, class_to_str
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import create_model, validator
+from pydantic.fields import ModelField, UndefinedType
 from pydantic.main import ModelMetaclass
 from typing_extensions import Annotated
 
 from PartSegCore.utils import BaseModel
 from PartSegImage import Channel
-
-if typing.TYPE_CHECKING:
-    from pydantic.fields import ModelField
 
 
 class AlgorithmDescribeNotFound(Exception):
@@ -575,7 +573,10 @@ def _field_to_algorithm_property(name: str, field: "ModelField"):
             )
         if issubclass(field.type_, AlgorithmSelection):
             value_type = AlgorithmDescribeBase
-            default_value = field.field_info.default.name
+            if isinstance(field.field_info.default, UndefinedType):
+                default_value = field.field_info.default_factory().name
+            else:
+                default_value = field.field_info.default.name
             possible_values = field.type_.__register__
 
     return AlgorithmProperty(

--- a/package/PartSegCore/segmentation/restartable_segmentation_algorithms.py
+++ b/package/PartSegCore/segmentation/restartable_segmentation_algorithms.py
@@ -444,7 +444,7 @@ class RangeThresholdAlgorithm(ThresholdBaseAlgorithm):
 
     def _threshold(self, image, thr=None):
         if thr is None:
-            thr: BaseThreshold = DoubleThresholdSelection[self.new_parameters.threshold.name]
+            thr: BaseThreshold = RangeThresholdSelection[self.new_parameters.threshold.name]
         mask, thr_val = thr.calculate_mask(image, self.mask, self.new_parameters.threshold.values, operator.ge)
         mask[mask == 2] = 0
         self.threshold_info = thr_val[::-1]

--- a/package/PartSegCore/segmentation/threshold.py
+++ b/package/PartSegCore/segmentation/threshold.py
@@ -323,6 +323,19 @@ class DoubleThreshold(BaseThreshold):
         return mask2, (thr_val1, thr_val2)
 
 
+class RangeThresholdParams(DoubleThresholdParams):
+    core_threshold: ThresholdSelection = Field(default_factory=ThresholdSelection.get_default, title="Upper threshold")
+    base_threshold: ThresholdSelection = Field(default_factory=ThresholdSelection.get_default, title="Lower threshold")
+
+
+class RangeThreshold(DoubleThreshold):
+    __argument_class__ = RangeThresholdParams
+
+    @classmethod
+    def get_name(cls):
+        return "Range"
+
+
 @register_class(version="0.0.1", migrations=[("0.0.1", rename_key("hist_num", "bins"))])
 class DoubleOtsuParams(BaseModel):
     valley: bool = Field(True, title="Valley emphasis")
@@ -488,6 +501,14 @@ DoubleThresholdSelection.register(DoubleThreshold)
 DoubleThresholdSelection.register(DoubleOtsu)
 DoubleThresholdSelection.register(MultipleOtsu)
 DoubleThresholdSelection.register(MaximumDistanceCore, old_names=["Maximum Distance Watershed"])
+
+
+class RangeThresholdSelection(AlgorithmSelection, class_methods=["calculate_mask"], suggested_base_class=BaseThreshold):
+    pass
+
+
+RangeThresholdSelection.register(RangeThreshold)
+RangeThresholdSelection.register(DoubleOtsu)
 
 
 def __getattr__(name):  # pragma: no cover

--- a/package/tests/conftest.py
+++ b/package/tests/conftest.py
@@ -25,7 +25,7 @@ from PartSegImage import Image
 
 @pytest.fixture(scope="module")
 def data_test_dir():
-    """Return path to directory with test data"""
+    """Return path to directory with test data that need to be downloaded"""
     return Path(__file__).absolute().parent.parent.parent / "test_data"
     # return os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "test_data")
 
@@ -37,7 +37,7 @@ def _mock_settings_path(tmp_path, monkeypatch):
 
 @pytest.fixture(scope="module")
 def bundle_test_dir():
-    """Return path to directory with test data"""
+    """Return path to directory with test data bundled in napari"""
     return Path(os.path.join(os.path.dirname(__file__), "test_data"))
 
 

--- a/package/tests/test_PartSegCore/test_io.py
+++ b/package/tests/test_PartSegCore/test_io.py
@@ -55,6 +55,7 @@ from PartSegCore.roi_info import ROIInfo
 from PartSegCore.segmentation.algorithm_base import AdditionalLayerDescription
 from PartSegCore.segmentation.noise_filtering import DimensionType
 from PartSegCore.segmentation.segmentation_algorithm import ThresholdAlgorithm
+from PartSegCore.segmentation.threshold import RangeThresholdSelection
 from PartSegCore.utils import ProfileDict, check_loaded_dict
 from PartSegImage import Image
 
@@ -708,6 +709,14 @@ def test_find_problematic_entries_nested():
     assert find_problematic_entries(data) == [data["ccc"]]
     data = {"aaa": 1, "bbb": 2, "ccc": {"ddd": 1, "eee": 2, "__error__": True}, "kkk": {"__error__": True, "a": 1}}
     assert find_problematic_entries(data) == [data["ccc"], data["kkk"]]
+
+
+def test_load_range_algorithm(bundle_test_dir):
+    data, err = LoadPlanJson.load([bundle_test_dir / "range_profile.json"])
+    assert err == []
+    assert len(data) == 1
+    assert isinstance(data["test_range"].values.threshold, RangeThresholdSelection)
+    assert data["test_range"].values.threshold.name == "Range"
 
 
 update_name_json = """

--- a/package/tests/test_PartSegCore/test_segmentation.py
+++ b/package/tests/test_PartSegCore/test_segmentation.py
@@ -204,7 +204,7 @@ class TestRangeThresholdAlgorithm:
         alg = sa.RangeThresholdAlgorithm()
         parameters = sa.RangeThresholdAlgorithm.__argument_class__(
             threshold={
-                "name": "Base/Core",
+                "name": "Range",
                 "values": {
                     "base_threshold": {
                         "name": "Manual",
@@ -248,7 +248,7 @@ class TestRangeThresholdAlgorithm:
         alg = sa.RangeThresholdAlgorithm()
         parameters = sa.RangeThresholdAlgorithm.__argument_class__(
             threshold={
-                "name": "Base/Core",
+                "name": "Range",
                 "values": {
                     "base_threshold": {
                         "name": "Manual",

--- a/package/tests/test_data/range_profile.json
+++ b/package/tests/test_data/range_profile.json
@@ -1,0 +1,118 @@
+{
+  "test_range": {
+    "__class__": "PartSegCore.algorithm_describe_base.ROIExtractionProfile",
+    "__class_version_dkt__": {
+      "PartSegCore.algorithm_describe_base.ROIExtractionProfile": "0.0.0",
+      "PartSegCore.utils.BaseModel": "0.0.0"
+    },
+    "__values__": {
+      "name": "test_range",
+      "algorithm": "Range threshold",
+      "values": {
+        "__class__": "PartSegCore.segmentation.restartable_segmentation_algorithms.RangeThresholdAlgorithmParameters",
+        "__class_version_dkt__": {
+          "PartSegCore.segmentation.restartable_segmentation_algorithms.RangeThresholdAlgorithmParameters": "0.0.2",
+          "PartSegCore.segmentation.restartable_segmentation_algorithms.ThresholdBaseAlgorithmParameters": "0.0.1",
+          "PartSegCore.utils.BaseModel": "0.0.0"
+        },
+        "__values__": {
+          "channel": {
+            "__class__": "PartSegImage.channel_class.Channel",
+            "__class_version_dkt__": {
+              "PartSegImage.channel_class.Channel": "0.0.0"
+            },
+            "__values__": {
+              "value": 1
+            }
+          },
+          "noise_filtering": {
+            "__class__": "PartSegCore.segmentation.noise_filtering.NoiseFilterSelection",
+            "__class_version_dkt__": {
+              "PartSegCore.segmentation.noise_filtering.NoiseFilterSelection": "0.0.0",
+              "PartSegCore.algorithm_describe_base.AlgorithmSelection": "0.0.0",
+              "PartSegCore.utils.BaseModel": "0.0.0"
+            },
+            "__values__": {
+              "name": "None",
+              "values": {
+                "__class__": "PartSegCore.utils.BaseModel",
+                "__class_version_dkt__": {
+                  "PartSegCore.utils.BaseModel": "0.0.0"
+                },
+                "__values__": {}
+              },
+              "class_path": "PartSegCore.segmentation.noise_filtering.NoneNoiseFiltering"
+            }
+          },
+          "minimum_size": 10,
+          "side_connection": false,
+          "threshold": {
+            "__class__": "PartSegCore.segmentation.threshold.DoubleThresholdSelection",
+            "__class_version_dkt__": {
+              "PartSegCore.segmentation.threshold.DoubleThresholdSelection": "0.0.0",
+              "PartSegCore.algorithm_describe_base.AlgorithmSelection": "0.0.0",
+              "PartSegCore.utils.BaseModel": "0.0.0"
+            },
+            "__values__": {
+              "name": "Base/Core",
+              "values": {
+                "__class__": "PartSegCore.segmentation.threshold.DoubleThresholdParams",
+                "__class_version_dkt__": {
+                  "PartSegCore.segmentation.threshold.DoubleThresholdParams": "0.0.0",
+                  "PartSegCore.utils.BaseModel": "0.0.0"
+                },
+                "__values__": {
+                  "core_threshold": {
+                    "__class__": "PartSegCore.segmentation.threshold.ThresholdSelection",
+                    "__class_version_dkt__": {
+                      "PartSegCore.segmentation.threshold.ThresholdSelection": "0.0.0",
+                      "PartSegCore.algorithm_describe_base.AlgorithmSelection": "0.0.0",
+                      "PartSegCore.utils.BaseModel": "0.0.0"
+                    },
+                    "__values__": {
+                      "name": "Manual",
+                      "values": {
+                        "__class__": "PartSegCore.segmentation.threshold.SingleThresholdParams",
+                        "__class_version_dkt__": {
+                          "PartSegCore.segmentation.threshold.SingleThresholdParams": "0.0.0",
+                          "PartSegCore.utils.BaseModel": "0.0.0"
+                        },
+                        "__values__": {
+                          "threshold": 20000.0
+                        }
+                      },
+                      "class_path": "PartSegCore.segmentation.threshold.ManualThreshold"
+                    }
+                  },
+                  "base_threshold": {
+                    "__class__": "PartSegCore.segmentation.threshold.ThresholdSelection",
+                    "__class_version_dkt__": {
+                      "PartSegCore.segmentation.threshold.ThresholdSelection": "0.0.0",
+                      "PartSegCore.algorithm_describe_base.AlgorithmSelection": "0.0.0",
+                      "PartSegCore.utils.BaseModel": "0.0.0"
+                    },
+                    "__values__": {
+                      "name": "Manual",
+                      "values": {
+                        "__class__": "PartSegCore.segmentation.threshold.SingleThresholdParams",
+                        "__class_version_dkt__": {
+                          "PartSegCore.segmentation.threshold.SingleThresholdParams": "0.0.0",
+                          "PartSegCore.utils.BaseModel": "0.0.0"
+                        },
+                        "__values__": {
+                          "threshold": 100.0
+                        }
+                      },
+                      "class_path": "PartSegCore.segmentation.threshold.ManualThreshold"
+                    }
+                  }
+                }
+              },
+              "class_path": "PartSegCore.segmentation.threshold.DoubleThreshold"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This Pr fix information on which threshold is lower and upper in the Range Threshold algorithm.

It removes Multiple Otsu and Maximum distance cores from the list of available methods as they will not be adequately used in this context. 