### PR TITLE
ci: Switch from setup.cfg to pyproject.toml in workflows

### DIFF
--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
           cache: 'pip'
-          cache-dependency-path: 'setup.cfg'
+          cache-dependency-path: 'pyproject.toml'
 
 #      - name: Install ubuntu libraries
 #        if: runner.os == 'Linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache-dependency-path: setup.cfg
+          cache-dependency-path: pyproject.toml
           cache: 'pip'
       - name: Install Dependencies
         run: |

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -26,22 +26,22 @@ jobs:
         with:
           python-version: "3.8"
           cache: pip
-          cache-dependency-path: 'setup.cfg'
+          cache-dependency-path: 'pyproject.toml'
       - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: pip
-          cache-dependency-path: 'setup.cfg'
+          cache-dependency-path: 'pyproject.toml'
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: pip
-          cache-dependency-path: 'setup.cfg'
+          cache-dependency-path: 'pyproject.toml'
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: pip
-          cache-dependency-path: 'setup.cfg'
+          cache-dependency-path: 'pyproject.toml'
       - name: Upgrade Python dependencies
         # ADD YOUR CUSTOM DEPENDENCY UPGRADE COMMANDS BELOW
         run: |
@@ -51,9 +51,9 @@ jobs:
 
           for pyv in 3.8 3.9 3.10 3.11; do
             python${pyv}  -m pip install -U pip pip-tools
-            python${pyv}  -m piptools compile --upgrade -o requirements/constraints_py${pyv}.txt  setup.cfg requirements/version_denylist.txt ${flags}
+            python${pyv}  -m piptools compile --upgrade -o requirements/constraints_py${pyv}.txt  pyproject.toml requirements/version_denylist.txt ${flags}
           done
-          python3.11 -m piptools compile --upgrade -o requirements/constraints_py3.11_docs.txt  setup.cfg requirements/version_denylist.txt --allow-unsafe --strip-extras --extra docs --extra pyqt6
+          python3.11 -m piptools compile --upgrade -o requirements/constraints_py3.11_docs.txt  pyproject.toml requirements/version_denylist.txt --allow-unsafe --strip-extras --extra docs --extra pyqt6
       # END PYTHON DEPENDENCIES
 
       - name: Check updated packages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to use `pyproject.toml` for dependency management and Python setup, enhancing compatibility across Python versions 3.8 to 3.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->