### PR TITLE
ci: Fix upgrade depenecies workflow

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -22,21 +22,7 @@ jobs:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       # START PYTHON DEPENDENCIES
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-          cache: pip
-          cache-dependency-path: 'pyproject.toml'
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-          cache: pip
-          cache-dependency-path: 'pyproject.toml'
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          cache: pip
-          cache-dependency-path: 'pyproject.toml'
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -46,14 +32,15 @@ jobs:
         # ADD YOUR CUSTOM DEPENDENCY UPGRADE COMMANDS BELOW
         run: |
           set -x
-          flags="--extra pyqt5 --extra pyqt6 --extra pyside2 --extra pyside6"
-          flags+=" --extra test --extra pyinstaller --allow-unsafe --strip-extras --resolver=backtracking"
+          pip install -U uv
+          set -x
+          flags=(--extra pyqt5 --extra pyqt6 --extra pyside2 --extra pyside6 --extra test --extra pyinstaller)
 
           for pyv in 3.8 3.9 3.10 3.11; do
-            python${pyv}  -m pip install -U pip pip-tools
-            python${pyv}  -m piptools compile --upgrade -o requirements/constraints_py${pyv}.txt  pyproject.toml requirements/version_denylist.txt ${flags}
+            uv pip compile --python-version ${pyv} --upgrade --output-file requirements/constraints_py${pyv}.txt pyproject.toml requirements/version_denylist.txt "${flags[@]}"
           done
-          python3.11 -m piptools compile --upgrade -o requirements/constraints_py3.11_docs.txt  pyproject.toml requirements/version_denylist.txt --allow-unsafe --strip-extras --extra docs --extra pyqt6
+          set +x
+          uv pip compile --python-version 3.11 --upgrade --output-file requirements/constraints_py3.11_docs.txt pyproject.toml requirements/version_denylist.txt --extra docs --extra pyqt6
       # END PYTHON DEPENDENCIES
 
       - name: Check updated packages

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -33,13 +33,11 @@ jobs:
         run: |
           set -x
           pip install -U uv
-          set -x
           flags=(--extra pyqt5 --extra pyqt6 --extra pyside2 --extra pyside6 --extra test --extra pyinstaller)
 
           for pyv in 3.8 3.9 3.10 3.11; do
             uv pip compile --python-version ${pyv} --upgrade --output-file requirements/constraints_py${pyv}.txt pyproject.toml requirements/version_denylist.txt "${flags[@]}"
           done
-          set +x
           uv pip compile --python-version 3.11 --upgrade --output-file requirements/constraints_py3.11_docs.txt pyproject.toml requirements/version_denylist.txt --extra docs --extra pyqt6
       # END PYTHON DEPENDENCIES
 

--- a/build_utils/check_updated_packages.py
+++ b/build_utils/check_updated_packages.py
@@ -4,7 +4,7 @@ import subprocess  # nosec
 import sys
 from pathlib import Path
 
-from tomli import loads
+from tomllib import loads
 
 name_re = re.compile(r"[\w-]+")
 changed_name_re = re.compile(r"\+([\w-]+)")

--- a/build_utils/check_updated_packages.py
+++ b/build_utils/check_updated_packages.py
@@ -2,8 +2,9 @@ import argparse
 import re
 import subprocess  # nosec
 import sys
-from configparser import ConfigParser
 from pathlib import Path
+
+from tomli import loads
 
 name_re = re.compile(r"[\w-]+")
 changed_name_re = re.compile(r"\+([\w-]+)")
@@ -31,12 +32,14 @@ if not args.main_packages:
     sys.exit(0)
 
 
-config = ConfigParser()
-config.read(src_dir / "setup.cfg")
+config = loads((src_dir / "pyproject.toml").read_text())
+
+metadata = config["project"]
+
 packages = (
-    config["options"]["install_requires"].split("\n")
-    + config["options.extras_require"]["pyinstaller"].split("\n")
-    + config["options.extras_require"]["all"].split("\n")
+    metadata["dependencies"]
+    + metadata["optional-dependencies"]["pyinstaller"]
+    + metadata["optional-dependencies"]["all"]
 )
 packages = [name_re.match(package).group().lower() for package in packages if name_re.match(package)]
 


### PR DESCRIPTION
The PR #1076 has broken upgrade dependence workflow. This PR is fixing it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the Python version to 3.11 and improved the dependency upgrade process.
	- Enhanced the package update checking script to support the latest Python packaging standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->