### PR TITLE
ci: Exclude pyside2 on python 3.11 and 3.12 from testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
 
   base-test-main:
     name: Base py${{ matrix.python_version }}
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
     uses: ./.github/workflows/base_test_workflow.yml
     needs: download_data
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
 
   base-test-main:
     name: Base py${{ matrix.python_version }}
-    # if: github.event_name == 'push'
+    if: github.event_name == 'push'
     uses: ./.github/workflows/base_test_workflow.yml
     needs: download_data
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,11 @@ jobs:
           - python_version: "3.9"
             os: "ubuntu-22.04"
             qt_backend: "PyQt6"
+        exclude:
+          - python_version: "3.11"
+            qt_backend: "PySide2"
+          - python_version: "3.12"
+            qt_backend: "PySide2"
     with:
       test_data: True
       python_version: ${{ matrix.python_version }}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Modified CI workflow to exclude specific Python versions with Qt backend PySide2, enhancing compatibility testing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->