### PR TITLE
ci: Bump macos runners to macos-13 (both azure and GHA)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         tox_args: [ "" ]
         include:
           - python_version: "3.9"
-            os: "macos-11"
+            os: "macos-13"
             qt_backend: "PyQt5"
           - python_version: "3.9"
             os: "windows-2019"
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: ["ubuntu-20.04", "macos-11", "windows-2019"]
+        os: ["ubuntu-20.04", "macos-13", "windows-2019"]
         qt_backend: ["PySide2", "PyQt5"]
         include:
           - python_version: "3.11"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,7 +139,7 @@ stages:
       strategy:
         matrix:
           macos:
-            imageName: 'macos-11'
+            imageName: 'macos-13'
           windows:
             imageName: 'windows-2019'
       pool: {vmImage: $(imageName)}
@@ -182,7 +182,7 @@ stages:
         strategy:
           matrix:
             macos:
-              imageName: 'macos-11'
+              imageName: 'macos-13'
               test_path: dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test
             windows:
               imageName: 'windows-2019'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CI/CD pipeline configurations to target macOS 13 for improved compatibility and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->