### PR TITLE
build: Do not create archive twice when create bundle

### DIFF
--- a/build_utils/create_and_pack_executable.py
+++ b/build_utils/create_and_pack_executable.py
@@ -22,7 +22,7 @@ def get_file_path(working_dir, with_version=True):
         file_name = f"PartSeg-{PartSeg.__version__}-{SYSTEM_NAME_DICT[platform.system()]}"
     else:
         file_name = f"PartSeg-{SYSTEM_NAME_DICT[platform.system()]}"
-    if platform.system() != "Darwin" and os.uname().machine == "arm64":
+    if platform.system() == "Darwin" and os.uname().machine == "arm64":
         file_name += "-arm64"
     if platform.system() != "Darwin":
         file_name += ".zip"


### PR DESCRIPTION
Instead of double archive cretion, just make copy with simpler name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved the process for creating and packing executables by separating file path retrieval from archive creation.

- **Refactor**
	- Renamed and restructured functions to enhance code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->