### PR TITLE
refactor: use `"left_to_right"` in place of smart union for pydantic 2 compatibility

### DIFF
--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -42,7 +42,7 @@ on:
 
 jobs:
   test:
-    name: ${{ inputs.os }} py ${{ inputs.python_version }} ${{ inputs.napari }} ${{ inputs.qt_backend }}
+    name: ${{ inputs.os }} py ${{ inputs.python_version }} ${{ inputs.napari }} ${{ inputs.qt_backend }} ${{ inputs.pydantic }}
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,10 @@ jobs:
           - python_version: "3.9"
             os: "ubuntu-22.04"
             qt_backend: "PyQt6"
+          - python_version: "3.10"
+            os: "ubuntu-22.04"
+            qt_backend: "PyQt5"
+            pydantic: "_pydantic_1"
         exclude:
           - python_version: "3.11"
             qt_backend: "PySide2"
@@ -113,6 +117,7 @@ jobs:
       python_version: ${{ matrix.python_version }}
       os: ${{ matrix.os }}
       qt_backend: ${{ matrix.qt_backend }}
+      pydantic: ${{ matrix.pydantic }}
 
   test_coverage:
     needs: download_data

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,7 @@ jobs:
       os: ${{ matrix.os }}
       qt_backend: ${{ matrix.qt_backend }}
       tox_args: ${{ matrix.tox_args }}
+      pydantic: ${{ matrix.pydantic }}
 
   base-test-main:
     name: Base py${{ matrix.python_version }}

--- a/package/PartSegCore/algorithm_describe_base.py
+++ b/package/PartSegCore/algorithm_describe_base.py
@@ -10,7 +10,7 @@ from importlib.metadata import version
 from local_migrator import REGISTER, class_to_str
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import create_model, validator
-from pydantic.fields import FieldInfo
+from pydantic.fields import Field, FieldInfo
 from typing_extensions import Annotated
 
 from PartSegCore.utils import BaseModel
@@ -400,13 +400,10 @@ class AlgorithmSelection(BaseModel, metaclass=AddRegisterMeta):  # pylint: disab
     """
 
     name: str
-    values: typing.Union[typing.Dict[str, typing.Any], PydanticBaseModel]
+    values: typing.Union[typing.Dict[str, typing.Any], PydanticBaseModel] = Field(..., union_mode="left_to_right")
     class_path: str = ""
     if typing.TYPE_CHECKING:
         __register__: Register
-
-    class Config:
-        smart_union = True
 
     @validator("name")
     def check_name(cls, v):

--- a/package/PartSegCore/algorithm_describe_base.py
+++ b/package/PartSegCore/algorithm_describe_base.py
@@ -8,6 +8,7 @@ from functools import wraps
 from importlib.metadata import version
 
 from local_migrator import REGISTER, class_to_str
+from packaging.version import parse as parse_version
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import create_model, validator
 from pydantic.fields import Field, FieldInfo
@@ -404,6 +405,11 @@ class AlgorithmSelection(BaseModel, metaclass=AddRegisterMeta):  # pylint: disab
     class_path: str = ""
     if typing.TYPE_CHECKING:
         __register__: Register
+
+    if parse_version(version("pydantic")) < parse_version("2"):
+
+        class Config:
+            smart_union = True
 
     @validator("name")
     def check_name(cls, v):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Added default values and adjusted type hints in the `AlgorithmSelection` class for improved configuration.
    - Included `pydantic` key in the matrix configuration for enhanced test coverage.

- **Chores**
    - Updated import statements to align with new dependencies.
    - Enhanced naming in the `test` job to reflect additional configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->