### PR TITLE
chore: fix bundle build by add missed `napari.yaml` files to bundle 

### DIFF
--- a/.github/project_dict.pws
+++ b/.github/project_dict.pws
@@ -1,4 +1,6 @@
-personal_ws-1.1 en 3
+personal_ws-1.1 en 5
 napari
 autoupdate
 aspell
+yaml
+yml

--- a/build_utils/create_and_pack_executable.py
+++ b/build_utils/create_and_pack_executable.py
@@ -83,6 +83,7 @@ def main():
     parser.add_argument(
         "--spec", default=os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "launcher.spec")
     )
+    parser.add_argument("--without-compress", action="store_true")
     parser.add_argument("--working-dir", default=os.path.abspath(os.curdir))
 
     args = parser.parse_args()
@@ -91,8 +92,9 @@ def main():
 
     dir_name = "PartSeg.app" if platform.system() == "Darwin2" else "PartSeg"
 
-    fix_qt_location(args.working_dir, dir_name)
-    archive_build(args.working_dir, dir_name)
+    if not args.without_compress:
+        fix_qt_location(args.working_dir, dir_name)
+        archive_build(args.working_dir, dir_name)
 
 
 if __name__ == "__main__":

--- a/launcher.spec
+++ b/launcher.spec
@@ -165,7 +165,7 @@ a = Analysis(
         ]
     ]
     + qt_data
-    + [(os.path.join(base_path, "plugins/itk_snap_save/__init__.py"), "plugins/itk_snap_save")]
+    + [(os.path.join(base_path, "napari.yaml"), "PartSeg")]
     + [(os.path.join(base_path, "plugins/napari_widgets/__init__.py"), "plugins/napari")]
     + [(os.path.join(base_path, "plugins/napari_widgets/simple_measurement_widget.py"), "plugins/napari")]
     # + [ ("Readme.md", "/"), ("changelog.md", "/")]
@@ -174,6 +174,8 @@ a = Analysis(
     + collect_data_files("dask")
     + collect_data_files("vispy")
     + collect_data_files("napari")
+    + collect_data_files("napari_svg")
+    + collect_data_files("napari_console")
     + collect_data_files("freetype")
     + collect_data_files("skimage")
     + collect_data_files("fonticon_fa6")


### PR DESCRIPTION
fix PARTSEG-TZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--without-compress` option for build script to skip compression.
  - Enhanced data collection for `napari_svg` and `napari_console` modules.
  - Updated file path references to improve integration with `PartSeg`.

- **Improvements**
  - Refined initialization logic for `self.ranges` in `PartSegImage` to ensure appropriate value transformation.

- **Maintenance**
  - Updated personal dictionary to include `yaml` and `yml` entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->