### PR TITLE
docs: Add link for download macOS arm bundle

### DIFF
--- a/.github/project_dict.pws
+++ b/.github/project_dict.pws
@@ -6,3 +6,4 @@ yaml
 yml
 ci
 pre
+macOS

--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,7 @@ This application is designed to help biologist with segmentation based on thresh
   - [Windows](https://github.com/4DNucleome/PartSeg/releases/latest/download/PartSeg-windows.zip) (build on Windows 10)
   - [Linux](https://github.com/4DNucleome/PartSeg/releases/latest/download/PartSeg-linux.zip) (build on Ubuntu 20.04)
   - [macOS](https://github.com/4DNucleome/PartSeg/releases/latest/download/PartSeg-macos.zip) (build on macOS 13)
+  - [macOS arm](https://github.com/4DNucleome/PartSeg/releases/latest/download/PartSeg-macos-arm64.zip) (build on macOS 14)
     There are reported problems with permissions systems on macOS. If you have a problem with starting the application, please try to run it from the terminal.
 
 - With pip:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new download link for macOS arm builds (`PartSeg-macos-arm64.zip`) compatible with macOS 14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->