### PR TITLE
ci: speedup tests by use `tox-uv`

### DIFF
--- a/.azure-pipelines/tests.yaml
+++ b/.azure-pipelines/tests.yaml
@@ -14,13 +14,14 @@ steps:
       path: $(Build.SourcesDirectory)/test_data
   - script: |
       pip install -U pip wheel setuptools virtualenv
-      pip install -r requirements/requirements_dev.txt
+      pip install -r requirements/requirements_dev.txt tox-uv
     displayName: "Install deps"
   - script: tox -e py311-PyQt5-azure
     displayName: "Run Tox"
     env:
       CODECOV_TOKEN: $(codecov_token_secret)
-      PIP_CONSTRAINT: requirements/constraints_py3.9.txt
+      PIP_CONSTRAINT: requirements/constraints_py3.11.txt
+      UV_CONSTRAINT: requirements/constraints_py3.11.txt
 
   - task: CopyFiles@2
     inputs:

--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements/requirements_dev.txt tox-gh-actions>=2.12.0 tox-min-req
+          python -m pip install -r requirements/requirements_dev.txt tox-gh-actions>=2.12.0 tox-min-req tox-uv
           pip list
 
       - name: Test with tox
@@ -95,6 +95,7 @@ jobs:
           NAPARI: ${{ inputs.napari }}
           BACKEND: ${{ inputs.qt_backend }}
           PIP_CONSTRAINT: requirements/constraints_py${{ inputs.python_version }}${{ inputs.pydantic }}.txt
+          UV_CONSTRAINT: requirements/constraints_py${{ inputs.python_version }}${{ inputs.pydantic }}.txt
 
       - uses: actions/upload-artifact@v4
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,7 @@ min_req_constraints=
 setenv =
     MINIMAL_REQUIREMENTS=1
     PIP_CONSTRAINT=
+    UV_CONSTRAINT=
 deps =
     {[base]deps}
     setuptools_scm[toml]>=3.4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated test workflows to include `tox-uv`.
  - Added `UV_CONSTRAINT` environment variable for more controlled test configurations.
  - Modified pip installation commands and constraints for compatibility with Python 3.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->