### PR TITLE
build: remove PyOpenGL-accelerate from dependencies because of numpy incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ PartSeg = "PartSeg:napari.yaml"
 
 [project.optional-dependencies]
 accelerate = [
-    "PyOpenGL-accelerate>=3.1.5 ; platform_machine != 'arm64'",
+#    "PyOpenGL-accelerate>=3.1.5 ; platform_machine != 'arm64'",
 ]
 all = [
     "PartSeg[accelerate,pyqt5]"
@@ -114,7 +114,7 @@ pyinstaller = [
     "PartSeg[pyinstaller_base,pyqt5]",
 ]
 pyinstaller_base = [
-    "PyOpenGL-accelerate>=3.1.5 ; platform_machine != 'arm64'",
+    "PartSeg[accelerate]",
     "PyInstaller",
     "pydantic",
 ]


### PR DESCRIPTION
The `PyOpenGL-accelerate` wheels are built against NumPy 1.x that make it impossible to switch to 3D rendering.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated optional dependencies for `accelerate` and `pyinstaller_base` to ensure better compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->