### PR TITLE
build: update install constraints on numpy and qt packages

### DIFF
--- a/.azure-pipelines/pyinstaller.yaml
+++ b/.azure-pipelines/pyinstaller.yaml
@@ -5,7 +5,7 @@ parameters:
   type: string
 
 steps:
-  - {task: UsePythonVersion@0, inputs: {versionSpec: '3.9', architecture: x64}}
+  - {task: UsePythonVersion@0, inputs: {versionSpec: '3.11', architecture: x64}}
   - template: pip_cache.yaml
     parameters:
       key: pyinstaller | requirements/constraints_py3.9.txt | "$(Agent.OS)" | "$(PY)"
@@ -13,7 +13,7 @@ steps:
   - bash: |
       python -m pip install -U pip wheel setuptools
     displayName: install libs
-  - bash: python -m pip install .[pyinstaller] -c requirements/constraints_py3.9.txt
+  - bash: python -m pip install .[pyinstaller] -c requirements/constraints_py3.11.txt
     displayName: install partseg
   - bash: |
       python  build_utils/create_and_pack_executable.py --no-simple-zip

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -41,8 +41,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-2022, macos-12, ubuntu-22.04]
-        python: [3.9]
+        platform: [windows-2022, macos-14, ubuntu-22.04]
+        python: [3.12]
     steps:
       - uses: actions/checkout@v4
 

--- a/build_utils/pyproject_toml_to_yaml.py
+++ b/build_utils/pyproject_toml_to_yaml.py
@@ -5,9 +5,27 @@ import tomllib
 base_dir = Path(__file__).parent.parent
 pyproject_toml = base_dir / "pyproject.toml"
 
+
+def drop_line(line):
+    if "python_version < '3.10'" in line:
+        return False
+
+    if "python_version < '3.11'" in line:  # noqa: SIM103
+        return False
+
+    return True
+
+
+def remove_specifier(line: str):
+    if ";" in line:
+        return line.split(";", maxsplit=1)[0]
+    return line
+
+
 with pyproject_toml.open("rb") as f:
     data = tomllib.load(f)
 dependencies = data["project"]["dependencies"]
+dependencies = map(remove_specifier, filter(drop_line, dependencies))
 dependencies_str = "\n".join([f"  - {v}" for v in dependencies])
 dependencies_str = dependencies_str.replace("qtconsole", "qtconsole-base")
 print(dependencies_str)

--- a/package/tests/conftest.py
+++ b/package/tests/conftest.py
@@ -42,7 +42,7 @@ def bundle_test_dir():
 
 @pytest.fixture()
 def image(tmp_path):
-    data = np.zeros([20, 20, 20, 2], dtype=np.uint8)
+    data = np.zeros([20, 20, 20, 2], dtype=np.uint16)
     data[10:-1, 1:-1, 1:-1, 0] = 20
     data[1:10, 1:-1, 1:-1, 1] = 20
     data[1:-1, 1:5, 1:-1, 1] = 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ dependencies = [
     "mahotas>=1.4.10",
     "napari>=0.4.14",
     "nme>=0.1.7",
-    "numpy>=1.18.5",
+    "numpy>=1.18.5 ; python_version >= '3.10'",
+    "numpy>=1.18.5, <2 ; python_version < '3.10'",
     "oiffile>=2020.1.18",
     "openpyxl>=2.5.7",
     "packaging>=20.0",
@@ -119,22 +120,26 @@ pyinstaller_base = [
     "pydantic",
 ]
 pyqt = [
-    "PyQt5!=5.15.0,>=5.12.3",
+    "PartSeg[pyqt5]",
 ]
 pyqt5 = [
     "PyQt5!=5.15.0,>=5.12.3",
+    "napari[pyqt5]",
 ]
 pyqt6 = [
     "PyQt6",
+     "napari[pyqt6]",
 ]
 pyside = [
-    "PySide2!=5.15.0,>=5.12.3",
+    "PartSeg[pyside2]",
 ]
 pyside2 = [
     "PySide2!=5.15.0,>=5.12.3",
+    "napari[pyside]",
 ]
 pyside6 = [
     "PySide6",
+    "napari[pyside6_experimental]",
 ]
 test = [
     "coverage",


### PR DESCRIPTION
Bump python version in some CI jobs 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated support for Python 3.11 in Azure Pipelines.
  - Updated GitHub Actions workflow to support macOS 14 and Python 3.12.

- **Dependencies**
  - Updated dependencies in `pyproject.toml` to conditionally include `numpy`, `napari`, and `PartSeg` based on Python versions.

- **Tests**
  - Modified test fixture data type from `np.uint8` to `np.uint16` for enhanced precision.

- **Refactor**
  - Added utility functions to streamline dependency specification handling in build utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->