### PR TITLE
ci: use python 3.11 to determine updated packages in PR description

### DIFF
--- a/build_utils/check_updated_packages.py
+++ b/build_utils/check_updated_packages.py
@@ -17,7 +17,7 @@ parser.add_argument("--main-packages", action="store_true")
 args = parser.parse_args()
 
 out = subprocess.run(  # nosec
-    ["git", "diff", str(src_dir / "requirements" / "constraints_py3.9.txt")],
+    ["git", "diff", str(src_dir / "requirements" / "constraints_py3.11.txt")],
     capture_output=True,
     check=True,
     shell=False,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the script to compare package requirements against `constraints_py3.11.txt` instead of `constraints_py3.9.txt`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->