### PR TITLE
build: require napari>=0.5.0 only for python 3.9+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ pyqt5 = [
 ]
 pyqt6 = [
     "PyQt6",
-     "napari[pyqt6]>=0.5.0",
+     "napari[pyqt6]>=0.5.0; python_version >= '3.9'",
 ]
 pyside = [
     "PartSeg[pyside2]",
@@ -139,7 +139,7 @@ pyside2 = [
 ]
 pyside6 = [
     "PySide6",
-    "napari[pyside6_experimental]>=0.5.0",
+    "napari[pyside6_experimental]>=0.5.0; python_version >= '3.9'",
 ]
 test = [
     "coverage",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced conditional dependencies for `napari` based on Python version, ensuring compatibility for users on Python 3.9 or higher.
  
- **Bug Fixes**
	- Enhanced dependency management to prevent potential compatibility issues in older Python environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->