### PR TITLE
fix: Fix trying to access to just deleted measurement profile from edit window.

### DIFF
--- a/package/PartSeg/_roi_analysis/advanced_window.py
+++ b/package/PartSeg/_roi_analysis/advanced_window.py
@@ -533,7 +533,9 @@ class MeasurementSettings(QWidget):
             self.profile_description.setText("")
             return
         item = self.profile_list.currentItem()
-        if item is None:
+        if item is None or item.text() not in self.settings.measurement_profiles:
+            # item.text() is not in self.settings.measurement_profiles just after delete
+            # when list content is not updated
             self.profile_description.setText("")
             return
         profile = self.settings.measurement_profiles[item.text()]


### PR DESCRIPTION
fix PARTSEG-VE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for validating selected items in the profile list to prevent errors related to deleted items.
	- Enhanced robustness of the application by accommodating edge cases in profile selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->