### PR TITLE
chore: Disable thumbnail generation in napari layer as it is fragile and not used

### DIFF
--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -60,6 +60,11 @@ else:
     USE_THREADS = True
 
 
+class _NapariImage(NapariImage):
+    def _update_thumbnail(self):
+        """Disable thumbnail update"""
+
+
 def get_highlight_colormap():
     cmap_dict = {0: (0, 0, 0, 0), 1: "white", None: (0, 0, 0, 0)}
     if _napari_ge_5:
@@ -1073,7 +1078,7 @@ def _prepare_layers(image: Image, param: ImageParameters, replace: bool) -> Tupl
         blending = "additive" if i != 0 else "translucent"
         data = image.get_channel(i)
 
-        layer = NapariImage(
+        layer = _NapariImage(
             data,
             colormap=param.colormaps[i],
             visible=param.visibility[i],

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -61,7 +61,7 @@ else:
 
 
 class _NapariImage(NapariImage):
-    def _update_thumbnail(self):
+    def _update_thumbnail(self, *_, **__):
         """Disable thumbnail update"""
 
 


### PR DESCRIPTION
This PR uses a private API, but should not be fragile as change name of function will only enable again thumbnail generation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced control over thumbnail management in the image processing workflow by disabling automatic updates for thumbnails in specific image layers.
- **Bug Fixes**
	- Resolved issues related to unintended thumbnail updates, improving the overall user experience when working with images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->