### PR TITLE
fix: Fix problem with setting range of auto-generated widget 

### DIFF
--- a/package/PartSeg/common_gui/algorithms_description.py
+++ b/package/PartSeg/common_gui/algorithms_description.py
@@ -599,7 +599,12 @@ class SubAlgorithmWidget(QWidget):
 
     def paintEvent(self, event: QPaintEvent):
         name = self.choose.currentText()
-        if self.widgets_dict[name].has_elements() and event.rect().top() == 0 and event.rect().left() == 0:
+        if (
+            name in self.widgets_dict
+            and self.widgets_dict[name].has_elements()
+            and event.rect().top() == 0
+            and event.rect().left() == 0
+        ):
             painter = QPainter(self)
             painter.drawRect(self.rect() - QMargins(1, -1, 1, 1))
 

--- a/package/PartSegCore/algorithm_describe_base.py
+++ b/package/PartSegCore/algorithm_describe_base.py
@@ -84,7 +84,7 @@ class AlgorithmProperty:
         else:
             self.value_type = type(default_value)
         self.default_value = default_value
-        self.range = options_range
+        self.range = tuple(self.value_type(x) for x in options_range) if options_range is not None else None
         self.possible_values = possible_values
         self.help_text = help_text
         self.per_dimension = per_dimension

--- a/package/PartSegCore/segmentation/threshold.py
+++ b/package/PartSegCore/segmentation/threshold.py
@@ -413,8 +413,8 @@ class MaximumDistanceWatershedParams(BaseModel):
     minimum_border_distance: int = Field(
         10,
         title="Border Radius",
-        ge=0.0,
-        le=100.0,
+        ge=0,
+        le=100,
         description="Minimum distance of local maxima from the border. To avoid artifacts",
     )
 


### PR DESCRIPTION
fix PARTSEG-WH
fix PARTSEG-WG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the robustness of the drawing logic to prevent potential errors related to widget access.
  
- **Enhancements**
	- Updated the assignment of the `range` attribute to ensure it consistently holds a tuple of the expected type.
	- Changed the type constraints for `minimum_border_distance` to enforce integer values, enhancing input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->