### PR TITLE
fix: Fix reading channel names from single channel czi files

### DIFF
--- a/package/PartSegImage/image_reader.py
+++ b/package/PartSegImage/image_reader.py
@@ -358,9 +358,11 @@ class CziImageReader(BaseImageReaderBuffer):
                 scale_info.get("Y", self.default_spacing[1]),
                 scale_info.get("X", self.default_spacing[2]),
             )
-            self.channel_names = [
-                x["Name"] for x in metadata["ImageDocument"]["Metadata"]["DisplaySetting"]["Channels"]["Channel"]
-            ]
+            channel_meta = metadata["ImageDocument"]["Metadata"]["DisplaySetting"]["Channels"]["Channel"]
+            if isinstance(channel_meta, dict):
+                # single channel saved in czifile
+                channel_meta = [channel_meta]
+            self.channel_names = [x["Name"] for x in channel_meta]
         # TODO add mask reading
         if isinstance(image_path, BytesIO):
             image_path = ""


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue with reading channel names from single channel CZI files by ensuring the channel metadata is correctly processed when it is a dictionary.

Bug Fixes:
- Fix reading channel names from single channel CZI files by handling the case where channel metadata is a dictionary instead of a list.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of channel metadata when reading image files, ensuring consistent population of channel names for both single and multiple channels.

- **Bug Fixes**
	- Resolved issues related to channel metadata processing that could occur with single-channel images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->