### PR TITLE
chore: use PyQt6 in pre-tests

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -84,7 +84,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           NAPARI: latest
-          BACKEND: PyQt5
+          BACKEND: PyQt6
           PIP_CONSTRAINT: requirements/pre_test_problematic_version.txt
           PIP_PRE: 1
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the CI workflow to switch the backend from PyQt5 to PyQt6 for pre-tests.

CI:
- Update the CI workflow to use PyQt6 instead of PyQt5 for pre-tests.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the backend framework from PyQt5 to PyQt6 in the testing workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->