### PR TITLE
feat: Read channel colors from `*.czi` metadata

### DIFF
--- a/.github/project_dict.pws
+++ b/.github/project_dict.pws
@@ -11,3 +11,4 @@ numpy
 pre
 bool
 changelog
+czi

--- a/package/PartSegCore/napari_plugins/loader.py
+++ b/package/PartSegCore/napari_plugins/loader.py
@@ -27,6 +27,7 @@ def _image_to_layers(project_info, scale, translate):
                     "blending": "additive",
                     "translate": translate,
                     "metadata": project_info.image.metadata,
+                    "colormap": project_info.image.get_colors()[i],
                 },
                 "image",
             )

--- a/package/PartSegCore/napari_plugins/loader.py
+++ b/package/PartSegCore/napari_plugins/loader.py
@@ -27,7 +27,6 @@ def _image_to_layers(project_info, scale, translate):
                     "blending": "additive",
                     "translate": translate,
                     "metadata": project_info.image.metadata,
-                    "colormap": project_info.image.get_colors()[i],
                 },
                 "image",
             )

--- a/package/PartSegImage/image.py
+++ b/package/PartSegImage/image.py
@@ -916,8 +916,8 @@ class Image:
                 res.append(color)
         return res
 
-    def get_colors(self):
-        res = []
+    def get_colors(self) -> list[str | list[int]]:
+        res: list[str | list[int]] = []
         for color in self.default_coloring:
             if isinstance(color, str):
                 res.append(color)

--- a/package/tests/test_PartSegImage/test_image_reader.py
+++ b/package/tests/test_PartSegImage/test_image_reader.py
@@ -39,6 +39,7 @@ class TestImageClass:
         assert np.count_nonzero(image.get_channel(0))
         assert image.channels == 4
         assert image.layers == 1
+        assert image.get_colors() == ["#FFFFFF", "#FF0000", "#00FF00", "#0000FF"]
 
         assert image.file_path == os.path.join(data_test_dir, "test_czi.czi")
 

--- a/package/tests/test_PartSegImage/test_image_reader.py
+++ b/package/tests/test_PartSegImage/test_image_reader.py
@@ -35,6 +35,7 @@ class TestImageClass:
         assert np.all(np.isclose(image.spacing, (7.752248561753867e-08,) * 2))
 
     def test_czi_file_read(self, data_test_dir):
+        """Check if czi file is read correctly."""
         image = CziImageReader.read_image(os.path.join(data_test_dir, "test_czi.czi"))
         assert np.count_nonzero(image.get_channel(0))
         assert image.channels == 4


### PR DESCRIPTION
Add reading information about channel colors from `czi` files.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Implement reading of channel colors from CZI metadata, refactor channel information handling, and add a test to ensure correct color extraction.

New Features:
- Add functionality to read channel colors from CZI metadata in image files.

Enhancements:
- Refactor channel information retrieval into a separate method `_get_channel_info` for better code organization.

Tests:
- Add a test to verify that channel colors are correctly read from CZI files.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to the `PartSegImage` class for retrieving channel information.
	- Enhanced the `read` method to populate color attributes from image metadata.
	- Added a new entry, `czi`, to the project dictionary for expanded functionality.

- **Improvements**
	- Improved type hinting and clarity for the `get_colors` method.

- **Bug Fixes**
	- Added assertions in tests to ensure the `get_colors()` method returns the expected color values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->