### PR TITLE
chore: Auto add "skip check PR title"  label in update dependencies PR

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -67,3 +67,5 @@ jobs:
 
             ${{ steps.packages.outputs.all_packages }}
           token: ${{ secrets.GHA_TOKEN }}
+          labels: |
+            skip check PR title


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the CI workflow to automatically add a label to dependency update pull requests, bypassing the PR title check.

CI:
- Automatically add the 'skip check PR title' label to pull requests created by the upgrade dependencies workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new label to the upgrade dependencies workflow to streamline the process by skipping checks on pull request titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->