### PR TITLE
chore: Stop using mambaforge in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,7 +190,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          miniforge-variant: mambaforge
           use-mamba: true
           channels: conda-forge
           channel-priority: strict


### PR DESCRIPTION
https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the GitHub Actions workflow to stop using the mambaforge variant in tests, following its deprecation.

CI:
- Remove the use of the mambaforge variant in the GitHub Actions workflow for tests.

<!-- Generated by sourcery-ai[bot]: end summary -->
