### PR TITLE
chore: Remove defining default version of language in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-    python: python3.8
-
 repos:
 -   repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.8.0


### PR DESCRIPTION
As all tools used in pre-commit config allow defining which python version needs to be supported, there is no longer need to pin this version i pre-commit config

## Summary by Sourcery

Chores:
- Remove the default Python version specification from the pre-commit configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the configuration file by removing the specified default Python version.
	- Adjusted indentation for improved YAML formatting while retaining existing hooks and repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->