### PR TITLE
chore: Use `PublishPipelineArtifact` in place of `PublishBuildArtifacts` to reduce CI fragility 

### DIFF
--- a/.azure-pipelines/pyinstaller.yaml
+++ b/.azure-pipelines/pyinstaller.yaml
@@ -22,6 +22,6 @@ steps:
   - task: PublishPipelineArtifact@1
     inputs:
       targetPath: dist2
-      publishLocation: execs
+      publishLocation: pipeline
   - script: ${{ parameters.test_path }}
     displayName: TestBuild

--- a/.azure-pipelines/pyinstaller.yaml
+++ b/.azure-pipelines/pyinstaller.yaml
@@ -19,9 +19,9 @@ steps:
       python  build_utils/create_and_pack_executable.py --no-simple-zip
     displayName: build
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     inputs:
-      pathToPublish: dist2
-      artifactName: execs
+      targetPath: dist2
+      publishLocation: execs
   - script: ${{ parameters.test_path }}
     displayName: TestBuild


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace `PublishBuildArtifacts` with `PublishPipelineArtifact` in the CI pipeline to enhance stability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Azure Pipelines configuration for improved artifact handling.
	- Introduced parameters for test path and cache directory.
	- Set Python version to 3.11 and architecture to x64 for consistency in builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->