### PR TITLE
chore: fix `upgrade-dependencies.yaml`docs constraints

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -39,7 +39,7 @@ jobs:
             uv pip compile --python-version ${pyv} --upgrade --output-file requirements/constraints_py${pyv}.txt pyproject.toml requirements/version_denylist.txt "${flags[@]}"
             uv pip compile --python-version ${pyv} --upgrade --output-file requirements/constraints_py${pyv}_pydantic_1.txt pyproject.toml requirements/version_denylist.txt "${flags[@]}" --constraint requirements/pydantic_1.txt
           done
-          uv pip compile --python-version 3.11 --upgrade --output-file requirements/constraints_py3.11_docs.txt pyproject.toml --extra docs --extra pyqt6
+          uv pip compile --python-version 3.12 --upgrade --output-file requirements/constraints_py3.12_docs.txt pyproject.toml --extra docs --extra pyqt6
       # END PYTHON DEPENDENCIES
 
       - name: Check updated packages


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the Python version from 3.11 to 3.12 in the upgrade-dependencies workflow for documentation constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Python version for dependency compilation from 3.11 to 3.12, resulting in a change to the output file name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->