### PR TITLE
fix: Drop imagej LUTs of size `24*x`

### DIFF
--- a/package/PartSegCore/napari_plugins/loader.py
+++ b/package/PartSegCore/napari_plugins/loader.py
@@ -18,7 +18,7 @@ def adjust_color(color: str) -> str: ...
 def adjust_color(color: list[int]) -> list[float]: ...
 
 
-def adjust_color(color: typing.Union[str, list[int]]) -> typing.Union[str, list[float]]:
+def adjust_color(color: typing.Union[str, list[int]]) -> typing.Union[str, tuple[float]]:
     # as napari ignore alpha channel in color, and adding it to
     # color cause that napari fails to detect that such colormap is already present
     # in this function I remove alpha channel if it is present
@@ -30,7 +30,7 @@ def adjust_color(color: typing.Union[str, list[int]]) -> typing.Union[str, list[
             # case when color is in format #RGBA
             return color[:4]
     elif isinstance(color, list):
-        return [color[i] / 255 for i in range(3)]
+        return (color[i] / 255 for i in range(3))
     # If not fit to an earlier case, return as is.
     # Maybe napari will handle it
     return color

--- a/package/PartSegImage/image_reader.py
+++ b/package/PartSegImage/image_reader.py
@@ -592,7 +592,7 @@ class TiffImageReader(BaseImageReaderBuffer):
     @staticmethod
     def _read_imagej_colors(image_file):
         colors = image_file.imagej_metadata.get("LUTs", [])
-        if colors and colors[0].shape[0] == 24:
+        if isinstance(colors, list) and colors and colors[0].shape[0] == 24:
             # drop buggy colors that comes from bug in PArtSeg with
             # writing 64 bit integers in tifffile
             return []

--- a/package/PartSegImage/image_reader.py
+++ b/package/PartSegImage/image_reader.py
@@ -589,6 +589,15 @@ class TiffImageReader(BaseImageReaderBuffer):
             x_spacing, y_spacing = self.default_spacing[2], self.default_spacing[1]
         return x_spacing, y_spacing
 
+    @staticmethod
+    def _read_imagej_colors(image_file):
+        colors = image_file.imagej_metadata.get("LUTs", [])
+        if colors and colors[0].shape[0] == 24:
+            # drop buggy colors that comes from bug in PArtSeg with
+            # writing 64 bit integers in tifffile
+            return []
+        return colors
+
     def read_imagej_metadata(self, image_file):
         try:
             z_spacing = image_file.imagej_metadata["spacing"] * name_to_scalar[image_file.imagej_metadata["unit"]]
@@ -596,7 +605,7 @@ class TiffImageReader(BaseImageReaderBuffer):
             z_spacing = self.default_spacing[0]
         x_spacing, y_spacing = self.read_resolution_from_tags(image_file)
         self.spacing = z_spacing, y_spacing, x_spacing
-        self.colors = image_file.imagej_metadata.get("LUTs", [])
+        self.colors = self._read_imagej_colors(image_file)
         self.channel_names = image_file.imagej_metadata.get("Labels", [])
         if "Ranges" in image_file.imagej_metadata:
             ranges = image_file.imagej_metadata["Ranges"]

--- a/package/tests/test_PartSegImage/test_image_writer.py
+++ b/package/tests/test_PartSegImage/test_image_writer.py
@@ -94,7 +94,7 @@ def test_imagej_write_all_metadata(tmp_path, data_test_dir):
 
     image2 = TiffImageReader.read_image(tmp_path / "image.tif")
 
-    npt.assert_array_equal(image2.default_coloring, image.default_coloring)
+    npt.assert_array_equal(image2.default_coloring, image.get_imagej_colors())
 
 
 def test_imagej_save_color(tmp_path):


### PR DESCRIPTION
In the past, The PartSeg wrote LUTs using 64 bits instead of 8 bits. I do not know how to decode it, so better drop it.

## Summary by Sourcery

Fix the handling of LUTs in PartSeg by dropping those with 64-bit integers and refactor the adjust_color function to return a tuple instead of a list.

Bug Fixes:
- Fix the issue of incorrectly written LUTs in PartSeg by dropping LUTs with 64-bit integers.

Enhancements:
- Refactor the adjust_color function to return a tuple instead of a list for color adjustments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new static method for improved handling of ImageJ color metadata, enhancing robustness when reading ImageJ files.

- **Bug Fixes**
	- Adjusted the color adjustment function to return a tuple for better compatibility with integer lists, improving color processing accuracy.

- **Tests**
	- Updated test assertions to reflect changes in how default coloring is retrieved, ensuring accurate validation of image properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->