### PR TITLE
chore: Drop python 3.9 tests for napari repository

### DIFF
--- a/.github/workflows/test_napari_repo.yml
+++ b/.github/workflows/test_napari_repo.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ ubuntu-24.04 ]
-        python: ['3.9' , '3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12']
         napari_version: ['repo']
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Ss napari drop python 3.9 stop testing i against napari repo

closes #1243

## Summary by Sourcery

CI:
- Remove Python 3.9 from the napari repository test matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated our automated testing configuration to focus on Python 3.10, 3.11, and 3.12 for enhanced compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->