### PR TITLE
fix: enable czifile workaround for 2019.7.2.1

### DIFF
--- a/.github/project_dict.pws
+++ b/.github/project_dict.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 15
+personal_ws-1.1 en 16
 napari
 autoupdate
 aspell
@@ -14,3 +14,4 @@ changelog
 czi
 PartSeg
 ROI
+czifile

--- a/package/PartSegImage/image_reader.py
+++ b/package/PartSegImage/image_reader.py
@@ -90,7 +90,7 @@ def decode_zstd0(data: bytes) -> np.ndarray:
     return np.frombuffer(imagecodecs.zstd_decode(data), dtype).copy()
 
 
-if parse_version(version("czifile")) == parse_version("2019.7.2"):
+if parse_version(version("czifile")) in {parse_version("2019.7.2"), parse_version("2019.7.2.1")}:
     DECOMPRESS[5] = decode_zstd0
     DECOMPRESS[6] = decode_zstd1
 


### PR DESCRIPTION
Closes #1245

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where the czifile workaround was not enabled for version 2019.7.2.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Expanded compatibility in image processing to support an additional library version, ensuring consistent decoding and functionality.
- **New Features**
	- Updated project dictionary version and added `czifile` entry for enhanced project tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->