### PR TITLE
ci: Block ipykernel 7.0.0a1

### DIFF
--- a/.github/project_dict.pws
+++ b/.github/project_dict.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 16
+personal_ws-1.1 en 17
 napari
 autoupdate
 aspell
@@ -15,3 +15,4 @@ czi
 PartSeg
 ROI
 czifile
+ipykernel

--- a/requirements/pre_test_problematic_version.txt
+++ b/requirements/pre_test_problematic_version.txt
@@ -1,2 +1,2 @@
 mpmath!=1.4.0a0
-ipykernel!=7.0.0a0
+ipykernel!=7.0.0a0,!=7.0.0a1


### PR DESCRIPTION
closes #1224 
closes #1238

As ipykernel==7.0.0a1 crash the `--pre` tests, then block it.

## Summary by Sourcery

Build:
- Blocks ipykernel version 7.0.0a1 in the pre_test_problematic_version.txt file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal versioning to reflect the latest release.
  - Enhanced dependency management by expanding compatibility constraints for a key package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->