### PR TITLE
chore:  Switch to `get_qapp` from `get_app` to handle napari deprecation

### DIFF
--- a/.github/project_dict.pws
+++ b/.github/project_dict.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 17
+personal_ws-1.1 en 18
 napari
 autoupdate
 aspell
@@ -16,3 +16,4 @@ PartSeg
 ROI
 czifile
 ipykernel
+qapp

--- a/package/PartSeg/launcher_main.py
+++ b/package/PartSeg/launcher_main.py
@@ -35,9 +35,12 @@ def _test_imports():  # pragma: no cover
         raise ImportError("napari_io not loaded")
 
     with suppress(ImportError):
-        from napari.qt import get_app
+        try:
+            from napari.qt import get_qapp  # napari>=0.5.4
+        except ImportError:
+            from napari.qt import get_app as get_qapp
 
-        get_app()
+        get_qapp()
 
     _setup_sentry()
     freetype.get_handle()


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Handle napari deprecation by switching to `get_qapp` and falling back to `get_app` for older versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chore**
  - Enhanced compatibility with the Napari library to ensure reliable application startup across different versions.
  - Updated version number for `personal_ws` and added a new project entry for `qapp`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->