### PR TITLE
chore: update workflow to use Ubuntu 22.04 instead of 20.04

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04", "windows-2019", "macos-13", "macos-14"]
+        os: ["ubuntu-22.04", "windows-2019", "macos-13", "macos-14"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_napari_widgets.yml
+++ b/.github/workflows/test_napari_widgets.yml
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/base_test_workflow.yml
     with:
       python_version: "3.9"
-      os: "ubuntu-20.04"
+      os: "ubuntu-24.04"
       napari: ${{ matrix.napari }}
       qt_backend: ${{ matrix.qt_backend }}
       timeout: 10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
 
   download_data:
     name: Download test data
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - shell: bash
@@ -65,7 +65,7 @@ jobs:
             os: "windows-latest"
             qt_backend: "PyQt5"
           - python_version: "3.10"
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             qt_backend: "PySide2"
           - python_version: "3.10"
             os: "ubuntu-24.04"


### PR DESCRIPTION
Because Ubuntu 20.04 runners are scheduled to disable, this PR bumps its version to the next LTS.

## Summary by Sourcery

Update GitHub Actions workflows to use Ubuntu 22.04 runners instead of Ubuntu 20.04

CI:
- Updated runner configurations in tests.yml, make_release.yml, and test_napari_widgets.yml to use ubuntu-22.04

Chores:
- Migrate CI runners from Ubuntu 20.04 to Ubuntu 22.04 across multiple workflow files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to use newer Ubuntu versions for build and test environments, improving compatibility and support for latest system libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->