### PR TITLE
chore: Try to fix Upgrade dependencies workflow

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -16,10 +16,10 @@ jobs:
       BRANCH_NAME: auto-dependency-upgrades
     steps:
       - uses: actions/checkout@v4
-        with:
-          # [Optional] Use a separate key to automatically execute checks on the resulting PR
-          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
+#        with:
+#          # [Optional] Use a separate key to automatically execute checks on the resulting PR
+#          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+#          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       # START PYTHON DEPENDENCIES
 


### PR DESCRIPTION
The documentation suggests that ssh key is no longe needed.

## Summary by Sourcery

Remove SSH key configuration from the dependency upgrade workflow

CI:
- Updated upgrade-dependencies.yml workflow to remove SSH key settings

Chores:
- Commented out SSH key configuration in the GitHub Actions workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration by disabling the use of a deployment SSH key in the dependency upgrade process. No changes to workflow functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->