### PR TITLE
chore: Add fallback version for `setuptools_scm`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "package/PartSeg/version.py"
+fallback_version = "0.16.3dev1"
 
 [project]
 name = "PartSeg"


### PR DESCRIPTION
https://github.com/napari/napari-plugin-template/issues/46

## Summary by Sourcery

Build:
- Add fallback_version = "0.16.3dev1" under [tool.setuptools_scm] in pyproject.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a fallback version configuration to improve version handling during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->