### PR TITLE
chore: block `sentry==3.0.0a1` for pre-tests

### DIFF
--- a/requirements/pre_test_problematic_version.txt
+++ b/requirements/pre_test_problematic_version.txt
@@ -1,2 +1,3 @@
 mpmath!=1.4.0a0
 ipykernel!=7.0.0a0,!=7.0.0a1
+sentry-sdk!=3.0.0a1


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add sentry==3.0.0a1 to requirements/pre_test_problematic_version.txt to block it in pre-tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated requirements to exclude a problematic version of a package, ensuring improved stability during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->