### PR TITLE
chore: Use ubuntu 22.04 when building pyinstaller bundle

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,7 +169,7 @@ stages:
           test_path: dist/PartSeg/PartSeg _test
           DISPLAY: ':99.0'
           pip_cache_dir: $(Pipeline.Workspace)/.pip
-        pool: { vmImage: 'Ubuntu-20.04' }
+        pool: { vmImage: 'Ubuntu-22.04' }
         steps:
           - template: .azure-pipelines/linux_libs.yaml
           - template: .azure-pipelines/pyinstaller.yaml


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch Azure Pipelines VM image from Ubuntu-20.04 to Ubuntu-22.04 for the PyInstaller bundle job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build pipeline to use a newer Ubuntu version for improved compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->