### PR TITLE
chore: Block sentry alpha 3.0.0a1 and 3.0.0a2

### DIFF
--- a/requirements/version_denylist.txt
+++ b/requirements/version_denylist.txt
@@ -4,4 +4,4 @@ PySide6 < 6.3.2 ; python_version < '3.10'
 PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2; python_version >= '3.10'
 npe2!=0.2.2
 imageio != 2.22.1
-sentry-sdk!=1.29.0
+sentry-sdk!=1.29.0,!=3.0.0a1,!=3.0.0a2


### PR DESCRIPTION
To prevent fails of CI.

## Summary by Sourcery

Block Sentry alpha versions 3.0.0a0 and 3.0.0a1 in the version denylist to prevent CI failures.

Chores:
- Add Sentry 3.0.0a0 to requirements/version_denylist.txt
- Add Sentry 3.0.0a1 to requirements/version_denylist.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded the denylist to block additional pre-release versions of the sentry-sdk package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->