### PR TITLE
chore: Migrate Windows images from 2019 to 2022 in Azure Pipelines and GitHub Actions

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-2019", "macos-13", "macos-14"]
+        os: ["ubuntu-22.04", "windows-2022", "macos-13", "macos-14"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,7 +141,7 @@ stages:
           macos:
             imageName: 'macos-13'
           windows:
-            imageName: 'windows-2019'
+            imageName: 'windows-2022'
       pool: {vmImage: $(imageName)}
       steps:
         - template: .azure-pipelines/tests.yaml
@@ -188,7 +188,7 @@ stages:
               imageName: 'macos-14'
               test_path: dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test
             windows:
-              imageName: 'windows-2019'
+              imageName: 'windows-2022'
               test_path: dist\PartSeg\PartSeg _test
         variables:
           pip_cache_dir: $(Pipeline.Workspace)/.pip

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Block sentry alpha 3.0.0a1 and 3.0.0a2 ([#1279](https://github.com/4DNucleome/PartSeg/pull/1279))
 - Block `pytest-qt==4.5.0` (for `pyside2` compatibility) ([#1282](https://github.com/4DNucleome/PartSeg/pull/1282))
 - [pre-commit.ci] pre-commit autoupdate ([#1280](https://github.com/4DNucleome/PartSeg/pull/1280))
+- Migrate Windows images from 2019 to 2022 in Azure Pipelines and GitHub Actions ([#1284](https://github.com/4DNucleome/PartSeg/pull/1284))
 
 ## 0.16.2 - 2025-05-12
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update Windows VM image references from windows-2019 to windows-2022 in azure-pipelines.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build and test environments to use the latest Windows VM image for improved compatibility and support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->