### PR TITLE
chore: Use prek for initial check of code format

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,9 +48,9 @@ stages:
               key: pre-commit | .pre-commit-config.yaml | "$(PY)"
               path: $(PRE_COMMIT_HOME)
           - bash: |
-              python -m pip install pre-commit
+              python -m pip install prek
             displayName: InstallDeps
-          - bash: pre-commit run --all --show-diff-on-failure
+          - bash: prek run --all --show-diff-on-failure
             displayName: pre-commmit
 
   - stage: manifest_check

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ stages:
               python -m pip install prek
             displayName: InstallDeps
           - bash: prek run --all-files --show-diff-on-failure
-            displayName: pre-commmit
+            displayName: Check Formatting (pre-commit hook)
 
   - stage: manifest_check
     dependsOn: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,19 +38,13 @@ stages:
       - job: check_formating
         pool:
           vmImage: ubuntu-latest
-        variables:
-          PRE_COMMIT_HOME: $(Pipeline.Workspace)/pre-commit-cache
         steps:
           - {task: UsePythonVersion@0, inputs: {versionSpec: '3.12', architecture: x64}}
           - script: echo "##vso[task.setvariable variable=PY]$(python -VV)"
-          - task: Cache@2
-            inputs:
-              key: pre-commit | .pre-commit-config.yaml | "$(PY)"
-              path: $(PRE_COMMIT_HOME)
           - bash: |
               python -m pip install prek
             displayName: InstallDeps
-          - bash: prek run --all --show-diff-on-failure
+          - bash: prek run --all-files --show-diff-on-failure
             displayName: pre-commmit
 
   - stage: manifest_check


### PR DESCRIPTION
## Summary by Sourcery

Replace pre-commit with prek in the initial code formatting stage of the Azure Pipelines CI

CI:
- Install prek instead of pre-commit in the pipeline dependencies step
- Run prek run --all --show-diff-on-failure in place of pre-commit run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Continuous integration updated to use a different formatting-check tool in the formatting stage.
  * Formatting-check pipeline step label adjusted to reflect the new tool.
  * An intermediate caching step in the formatting stage was removed.
  * No impact on application features, performance, or UI; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->