### PR TITLE
fix: Fix saving in batch if the data is mask segmentation project

### DIFF
--- a/package/PartSegCore/analysis/batch_processing/batch_backend.py
+++ b/package/PartSegCore/analysis/batch_processing/batch_backend.py
@@ -352,7 +352,7 @@ class CalculationProcess:
             history=self.history,
             algorithm_parameters=self.algorithm_parameters,
         )
-        save_path = get_save_path(operation, self.calculation, self.image.file_path)
+        save_path = get_save_path(operation, self.calculation)
         save_dir = os.path.dirname(save_path)
         os.makedirs(save_dir, exist_ok=True)
         save_class.save(save_path, project_tuple, operation.values)

--- a/package/PartSegCore/analysis/batch_processing/batch_backend.py
+++ b/package/PartSegCore/analysis/batch_processing/batch_backend.py
@@ -352,7 +352,7 @@ class CalculationProcess:
             history=self.history,
             algorithm_parameters=self.algorithm_parameters,
         )
-        save_path = get_save_path(operation, self.calculation)
+        save_path = get_save_path(operation, self.calculation, self.image.file_path)
         save_dir = os.path.dirname(save_path)
         os.makedirs(save_dir, exist_ok=True)
         save_class.save(save_path, project_tuple, operation.values)

--- a/package/PartSegCore/analysis/batch_processing/batch_backend.py
+++ b/package/PartSegCore/analysis/batch_processing/batch_backend.py
@@ -209,6 +209,8 @@ class CalculationProcess:
         if isinstance(projects, ProjectTuple):
             projects = [projects]
         for project in projects:
+            sub_calculation = FileCalculation(project.image.file_path, calculation.calculation)
+            self.calculation = sub_calculation
             try:
                 self.image = project.image
                 if calculation.overwrite_voxel_size:
@@ -223,14 +225,16 @@ class CalculationProcess:
                     self.history = project.history
                     self.algorithm_parameters = project.algorithm_parameters
 
-                self.iterate_over(calculation.calculation_plan.execution_tree)
+                self.iterate_over(sub_calculation.calculation_plan.execution_tree)
                 for el in self.measurement:
-                    el.set_filename(path.relpath(project.image.file_path, calculation.base_prefix))
+                    el.set_filename(path.relpath(project.image.file_path, sub_calculation.base_prefix))
                 self.results.append(
-                    ResponseData(path.relpath(project.image.file_path, calculation.base_prefix), self.measurement)
+                    ResponseData(path.relpath(project.image.file_path, sub_calculation.base_prefix), self.measurement)
                 )
             except Exception as e:  # pylint: disable=broad-except
                 self.results.append(prepare_error_data(e))
+            finally:
+                self.calculation = calculation
             self._reset_image_cache()
         return self.results
 

--- a/package/PartSegCore/analysis/calculation_plan.py
+++ b/package/PartSegCore/analysis/calculation_plan.py
@@ -141,7 +141,7 @@ class MeasurementCalculate(BaseModel):
         return f"MeasurementCalculate \nChannel: {channel}\nUnits: {self.units}\n{desc}\n"
 
 
-def get_save_path(op: Save, calculation: "FileCalculation", image_file_path: str) -> str:
+def get_save_path(op: Save, calculation: "FileCalculation") -> str:
     """
     Calculate save path base on proceeded file path and save operation parameters.
     It assume that save algorithm is registered in :py:data:`PartSegCore.analysis.save_functions.save_dict`
@@ -153,7 +153,7 @@ def get_save_path(op: Save, calculation: "FileCalculation", image_file_path: str
     from PartSegCore.analysis.save_functions import save_dict  # noqa: PLC0415
 
     extension = save_dict[op.algorithm].get_default_extension()
-    rel_path = os.path.relpath(image_file_path, calculation.base_prefix)
+    rel_path = os.path.relpath(calculation.file_path, calculation.base_prefix)
     rel_path = os.path.splitext(rel_path)[0]
     if op.directory:
         file_name = os.path.basename(rel_path)

--- a/package/PartSegCore/analysis/calculation_plan.py
+++ b/package/PartSegCore/analysis/calculation_plan.py
@@ -141,7 +141,7 @@ class MeasurementCalculate(BaseModel):
         return f"MeasurementCalculate \nChannel: {channel}\nUnits: {self.units}\n{desc}\n"
 
 
-def get_save_path(op: Save, calculation: "FileCalculation") -> str:
+def get_save_path(op: Save, calculation: "FileCalculation", image_file_path: str) -> str:
     """
     Calculate save path base on proceeded file path and save operation parameters.
     It assume that save algorithm is registered in :py:data:`PartSegCore.analysis.save_functions.save_dict`
@@ -153,7 +153,7 @@ def get_save_path(op: Save, calculation: "FileCalculation") -> str:
     from PartSegCore.analysis.save_functions import save_dict  # noqa: PLC0415
 
     extension = save_dict[op.algorithm].get_default_extension()
-    rel_path = os.path.relpath(calculation.file_path, calculation.base_prefix)
+    rel_path = os.path.relpath(image_file_path, calculation.base_prefix)
     rel_path = os.path.splitext(rel_path)[0]
     if op.directory:
         file_name = os.path.basename(rel_path)

--- a/package/tests/test_PartSegCore/test_analysis_batch.py
+++ b/package/tests/test_PartSegCore/test_analysis_batch.py
@@ -39,7 +39,7 @@ from PartSegCore.analysis.calculation_plan import (
 )
 from PartSegCore.analysis.measurement_base import AreaType, Leaf, MeasurementEntry, Node, PerComponent
 from PartSegCore.analysis.measurement_calculation import MeasurementProfile
-from PartSegCore.analysis.save_functions import save_dict
+from PartSegCore.analysis.save_functions import SaveAsTiff, save_dict
 from PartSegCore.image_operations import RadiusType
 from PartSegCore.io_utils import LoadPlanExcel, SaveBase
 from PartSegCore.json_hooks import PartSegEncoder
@@ -262,7 +262,20 @@ def calculation_plan2(ltww_segmentation, measurement_list):
     ltww_segmentation.values.channel = 0
 
     tree = CalculationTree(
-        RootType.Mask_project, [CalculationTree(ltww_segmentation, [CalculationTree(measurement_list, [])])]
+        RootType.Mask_project,
+        [
+            CalculationTree(ltww_segmentation, [CalculationTree(measurement_list, [])]),
+            CalculationTree(
+                Save(
+                    suffix="_suffix",
+                    directory="sub",
+                    algorithm=SaveAsTiff.get_name(),
+                    short_name=SaveAsTiff.get_short_name(),
+                    values={},
+                ),
+                [],
+            ),
+        ],
     )
     return CalculationPlan(tree=tree, name="test2")
 
@@ -605,14 +618,14 @@ class TestCalculationProcess:
         str(df2.loc[0]["error description"]).startswith("[Errno 2]")
 
     @pytest.mark.filterwarnings("ignore:This method will be removed")
-    def test_full_pipeline_mask_project(self, tmpdir, data_test_dir, calculation_plan2):
+    def test_full_pipeline_mask_project(self, tmp_path, data_test_dir, calculation_plan2):
         file_pattern = os.path.join(data_test_dir, "*nucleus.seg")
         file_paths = glob(file_pattern)
         calc = Calculation(
             file_paths,
             base_prefix=data_test_dir,
-            result_prefix=data_test_dir,
-            measurement_file_path=os.path.join(tmpdir, "test2.xlsx"),
+            result_prefix=str(tmp_path),
+            measurement_file_path=os.path.join(tmp_path, "test2.xlsx"),
             sheet_name="Sheet1",
             calculation_plan=calculation_plan2,
             voxel_size=(1, 1, 1),
@@ -623,9 +636,13 @@ class TestCalculationProcess:
         manager.add_calculation(calc)
         wait_for_calculation(manager)
 
-        assert os.path.exists(os.path.join(tmpdir, "test2.xlsx"))
-        df = pd.read_excel(os.path.join(tmpdir, "test2.xlsx"), index_col=0, header=[0, 1], engine=ENGINE)
+        assert os.path.exists(os.path.join(tmp_path, "test2.xlsx"))
+        df = pd.read_excel(os.path.join(tmp_path, "test2.xlsx"), index_col=0, header=[0, 1], engine=ENGINE)
         assert df.shape == (2, 4)
+        assert (tmp_path / "sub").is_dir()
+        assert len(list((tmp_path / "sub").iterdir())) == 2
+        assert (tmp_path / "sub" / "test_nucleus_component1_suffix.tiff").exists()
+        assert (tmp_path / "sub" / "test_nucleus_component3_suffix.tiff").exists()
 
     def test_do_calculation(self, tmpdir, data_test_dir, calculation_plan3):
         file_path = os.path.join(data_test_dir, "stack1_components", "stack1_component1.tif")

--- a/package/tests/test_PartSegCore/test_analysis_batch.py
+++ b/package/tests/test_PartSegCore/test_analysis_batch.py
@@ -39,7 +39,7 @@ from PartSegCore.analysis.calculation_plan import (
 )
 from PartSegCore.analysis.measurement_base import AreaType, Leaf, MeasurementEntry, Node, PerComponent
 from PartSegCore.analysis.measurement_calculation import MeasurementProfile
-from PartSegCore.analysis.save_functions import save_dict
+from PartSegCore.analysis.save_functions import SaveAsTiff, save_dict
 from PartSegCore.image_operations import RadiusType
 from PartSegCore.io_utils import LoadPlanExcel, SaveBase
 from PartSegCore.json_hooks import PartSegEncoder
@@ -262,7 +262,20 @@ def calculation_plan2(ltww_segmentation, measurement_list):
     ltww_segmentation.values.channel = 0
 
     tree = CalculationTree(
-        RootType.Mask_project, [CalculationTree(ltww_segmentation, [CalculationTree(measurement_list, [])])]
+        RootType.Mask_project,
+        [
+            CalculationTree(ltww_segmentation, [CalculationTree(measurement_list, [])]),
+            CalculationTree(
+                Save(
+                    suffix="_suffix",
+                    directory="sub",
+                    algorithm=SaveAsTiff.get_name(),
+                    short_name=SaveAsTiff.get_short_name(),
+                    values={},
+                ),
+                [],
+            ),
+        ],
     )
     return CalculationPlan(tree=tree, name="test2")
 
@@ -605,14 +618,14 @@ class TestCalculationProcess:
         str(df2.loc[0]["error description"]).startswith("[Errno 2]")
 
     @pytest.mark.filterwarnings("ignore:This method will be removed")
-    def test_full_pipeline_mask_project(self, tmpdir, data_test_dir, calculation_plan2):
+    def test_full_pipeline_mask_project(self, tmp_path, data_test_dir, calculation_plan2):
         file_pattern = os.path.join(data_test_dir, "*nucleus.seg")
         file_paths = glob(file_pattern)
         calc = Calculation(
             file_paths,
             base_prefix=data_test_dir,
-            result_prefix=data_test_dir,
-            measurement_file_path=os.path.join(tmpdir, "test2.xlsx"),
+            result_prefix=tmp_path,
+            measurement_file_path=os.path.join(tmp_path, "test2.xlsx"),
             sheet_name="Sheet1",
             calculation_plan=calculation_plan2,
             voxel_size=(1, 1, 1),
@@ -623,9 +636,13 @@ class TestCalculationProcess:
         manager.add_calculation(calc)
         wait_for_calculation(manager)
 
-        assert os.path.exists(os.path.join(tmpdir, "test2.xlsx"))
-        df = pd.read_excel(os.path.join(tmpdir, "test2.xlsx"), index_col=0, header=[0, 1], engine=ENGINE)
+        assert os.path.exists(os.path.join(tmp_path, "test2.xlsx"))
+        df = pd.read_excel(os.path.join(tmp_path, "test2.xlsx"), index_col=0, header=[0, 1], engine=ENGINE)
         assert df.shape == (2, 4)
+        assert (tmp_path / "sub").is_dir()
+        assert len(list((tmp_path / "sub").iterdir())) == 2
+        assert (tmp_path / "sub" / "test_nucleus_component1_suffix.tiff").exists()
+        assert (tmp_path / "sub" / "test_nucleus_component3_suffix.tiff").exists()
 
     def test_do_calculation(self, tmpdir, data_test_dir, calculation_plan3):
         file_path = os.path.join(data_test_dir, "stack1_components", "stack1_component1.tif")

--- a/package/tests/test_PartSegCore/test_analysis_batch.py
+++ b/package/tests/test_PartSegCore/test_analysis_batch.py
@@ -39,7 +39,7 @@ from PartSegCore.analysis.calculation_plan import (
 )
 from PartSegCore.analysis.measurement_base import AreaType, Leaf, MeasurementEntry, Node, PerComponent
 from PartSegCore.analysis.measurement_calculation import MeasurementProfile
-from PartSegCore.analysis.save_functions import SaveAsTiff, save_dict
+from PartSegCore.analysis.save_functions import save_dict
 from PartSegCore.image_operations import RadiusType
 from PartSegCore.io_utils import LoadPlanExcel, SaveBase
 from PartSegCore.json_hooks import PartSegEncoder
@@ -262,20 +262,7 @@ def calculation_plan2(ltww_segmentation, measurement_list):
     ltww_segmentation.values.channel = 0
 
     tree = CalculationTree(
-        RootType.Mask_project,
-        [
-            CalculationTree(ltww_segmentation, [CalculationTree(measurement_list, [])]),
-            CalculationTree(
-                Save(
-                    suffix="_suffix",
-                    directory="sub",
-                    algorithm=SaveAsTiff.get_name(),
-                    short_name=SaveAsTiff.get_short_name(),
-                    values={},
-                ),
-                [],
-            ),
-        ],
+        RootType.Mask_project, [CalculationTree(ltww_segmentation, [CalculationTree(measurement_list, [])])]
     )
     return CalculationPlan(tree=tree, name="test2")
 
@@ -618,14 +605,14 @@ class TestCalculationProcess:
         str(df2.loc[0]["error description"]).startswith("[Errno 2]")
 
     @pytest.mark.filterwarnings("ignore:This method will be removed")
-    def test_full_pipeline_mask_project(self, tmp_path, data_test_dir, calculation_plan2):
+    def test_full_pipeline_mask_project(self, tmpdir, data_test_dir, calculation_plan2):
         file_pattern = os.path.join(data_test_dir, "*nucleus.seg")
         file_paths = glob(file_pattern)
         calc = Calculation(
             file_paths,
             base_prefix=data_test_dir,
-            result_prefix=tmp_path,
-            measurement_file_path=os.path.join(tmp_path, "test2.xlsx"),
+            result_prefix=data_test_dir,
+            measurement_file_path=os.path.join(tmpdir, "test2.xlsx"),
             sheet_name="Sheet1",
             calculation_plan=calculation_plan2,
             voxel_size=(1, 1, 1),
@@ -636,13 +623,9 @@ class TestCalculationProcess:
         manager.add_calculation(calc)
         wait_for_calculation(manager)
 
-        assert os.path.exists(os.path.join(tmp_path, "test2.xlsx"))
-        df = pd.read_excel(os.path.join(tmp_path, "test2.xlsx"), index_col=0, header=[0, 1], engine=ENGINE)
+        assert os.path.exists(os.path.join(tmpdir, "test2.xlsx"))
+        df = pd.read_excel(os.path.join(tmpdir, "test2.xlsx"), index_col=0, header=[0, 1], engine=ENGINE)
         assert df.shape == (2, 4)
-        assert (tmp_path / "sub").is_dir()
-        assert len(list((tmp_path / "sub").iterdir())) == 2
-        assert (tmp_path / "sub" / "test_nucleus_component1_suffix.tiff").exists()
-        assert (tmp_path / "sub" / "test_nucleus_component3_suffix.tiff").exists()
 
     def test_do_calculation(self, tmpdir, data_test_dir, calculation_plan3):
         file_path = os.path.join(data_test_dir, "stack1_components", "stack1_component1.tif")


### PR DESCRIPTION
## Summary by Sourcery

Ensure Save steps are correctly executed in batch mode for mask segmentation projects by using per-project calculation context and adjusting path prefixes

Bug Fixes:
- Use a sub_calculation context in batch_backend.do_calculation to iterate over each project’s execution tree and apply the correct base_prefix for file paths
- Restore the original calculation context after each project to prevent state leakage

Tests:
- Migrate pipeline test to pytest’s tmp_path fixture, add a Save node to the mask project plan, and assert that both Excel and TIFF outputs appear in the expected subdirectory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Batch processing can now save results as TIFF files per project, with configurable suffixes and a dedicated subdirectory.
* Improvements
  * Per-project execution in batch processing is more reliable, with consistent filename and path handling across projects.
* Bug Fixes
  * Ensures calculation state is correctly restored after each project, reducing risk of cross-project interference during batch runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->