### PR TITLE
chore: update licensing metadata to follow modern standards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=61.2.0", "setuptools_scm[toml]>=8"]  # PEP 508 specifications.
+requires = ["setuptools>=77.0.0", "setuptools_scm[toml]>=8"]  # PEP 508 specifications.
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Resolve warnings:
```
adding license file 'License.txt'
writing manifest file 'package/PartSeg.egg-info/SOURCES.txt'
/home/czaki/.cache/uv/builds-v0/.tmpPch8eG/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
/home/czaki/.cache/uv/builds-v0/.tmpPch8eG/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:55: SetuptoolsDeprecationWarning: 'tool.setuptools.license-files' is deprecated in favor of 'project.license-files' (available on setuptools>=77.0.0).
!!

        ********************************************************************************

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files for details.
        ********************************************************************************

!!
  _apply_tool_table(dist, config, filename)
/home/czaki/.cache/uv/builds-v0/.tmpPch8eG/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: BSD License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  dist._finalize_license_expression()
/home/czaki/.cache/uv/builds-v0/.tmpPch8eG/lib/python3.11/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: BSD License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized package license to BSD-3-Clause in project metadata for consistent display across platforms.
  * Removed redundant readme/license metadata entries to avoid duplication.

* **Chores**
  * Consolidated license information under the main project metadata while preserving reference to License.txt.
  * Updated packaging build requirements to a newer setuptools baseline; no functional changes to the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->