### PR TITLE
chore: Use ruff formatter in place of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,4 @@
 repos:
--   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.9.0
-    hooks:
-    - id: black
-      pass_filenames: true
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -20,6 +15,7 @@ repos:
     rev: v0.14.0
     hooks:
       - id: ruff-check
+      - id: ruff-format
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/package/PartSeg/_roi_analysis/prepare_plan_widget.py
+++ b/package/PartSeg/_roi_analysis/prepare_plan_widget.py
@@ -867,7 +867,7 @@ class CreatePlan(QWidget):
         conflict_mask, used_mask = self.calculation_plan.get_file_mask_names()
         if len(conflict_mask) > 0:
             logging.info("Mask in use")
-            show_warning("In use", f'Masks {", ".join(conflict_mask)} are used in other places')
+            show_warning("In use", f"Masks {', '.join(conflict_mask)} are used in other places")
 
             return
         self.mask_set -= used_mask

--- a/package/PartSeg/common_gui/algorithms_description.py
+++ b/package/PartSeg/common_gui/algorithms_description.py
@@ -70,7 +70,7 @@ def _pretty_print(data, indent=2) -> str:
     if isinstance(data, typing.Mapping):
         res = "\n"
         for k, v in data.items():
-            res += f"{' ' * indent}{k}: {_pretty_print(v, indent+2)}\n"
+            res += f"{' ' * indent}{k}: {_pretty_print(v, indent + 2)}\n"
         return res[:-1]
     return str(data)
 

--- a/package/PartSeg/common_gui/multiple_file_widget.py
+++ b/package/PartSeg/common_gui/multiple_file_widget.py
@@ -264,7 +264,7 @@ class MultipleFileWidget(QWidget):
             return
         normed_file_path = os.path.normpath(state.file_path)
         sub_dict = self.state_dict[normed_file_path]
-        name = f"state {self.state_dict_count[normed_file_path]+1}"
+        name = f"state {self.state_dict_count[normed_file_path] + 1}"
         if custom_name:
             name, ok = QInputDialog.getText(self, "Save name", "Save name:", text=name)
             if not ok:

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -1050,7 +1050,7 @@ def _print_dict(dkt: MutableMapping, indent="") -> str:
     res = []
     for k, v in dkt.items():
         if isinstance(v, MutableMapping):
-            res.append(f'{indent}{k}:\n{_print_dict(v, f"{indent}  ")}')
+            res.append(f"{indent}{k}:\n{_print_dict(v, f'{indent}  ')}")
         else:
             res.append(f"{indent}{k}: {v}")
     return "\n".join(res)

--- a/package/PartSeg/plugins/napari_io/save_tiff_layer.py
+++ b/package/PartSeg/plugins/napari_io/save_tiff_layer.py
@@ -42,11 +42,11 @@ def napari_write_images(path: str, layer_data: list[FullLayerData]) -> list[str]
         if data.shape[-1] < 6:
             axes += "C"
             scale_shift -= 1
-            channel_names = [f'{meta["name"]} {i}' for i in range(1, data.shape[-1] + 1)]
+            channel_names = [f"{meta['name']} {i}" for i in range(1, data.shape[-1] + 1)]
         axes = axes[-data.ndim :]
     else:
         data = [x[0] for x in layer_data]
-        axes = f"C{axes[-len(data[0].shape):]}"
+        axes = f"C{axes[-len(data[0].shape) :]}"
         scale_shift -= 1
     image = Image(
         data,

--- a/package/PartSegCore/analysis/batch_processing/batch_backend.py
+++ b/package/PartSegCore/analysis/batch_processing/batch_backend.py
@@ -867,19 +867,21 @@ class FileData:
         description = calculation_plan.pretty_print().split("\n")
         for i in range(math.ceil(len(description) / MAX_ROWS_IN_EXCEL_CELL)):
             to_write = description[i * MAX_ROWS_IN_EXCEL_CELL : (i + 1) * MAX_ROWS_IN_EXCEL_CELL]
-            sheet.write(f"A{i+2}", "\n".join(to_write))
+            sheet.write(f"A{i + 2}", "\n".join(to_write))
             sheet.set_row(i + 1, len(to_write) * 11 + 10)
 
         sheet.set_column(0, 0, max(map(len, description)))
         sheet.set_column(1, 1, 15)
         calculation_plan_str = json.dumps(calculation_plan, cls=PartSegEncoder)
         for i in range(math.ceil(len(calculation_plan_str) / MAX_CHAR_IN_EXCEL_CELL)):
-            sheet.write(f"B{i+2}", calculation_plan_str[i * MAX_CHAR_IN_EXCEL_CELL : (i + 1) * MAX_CHAR_IN_EXCEL_CELL])
+            sheet.write(
+                f"B{i + 2}", calculation_plan_str[i * MAX_CHAR_IN_EXCEL_CELL : (i + 1) * MAX_CHAR_IN_EXCEL_CELL]
+            )
 
         calculation_plan_pretty = json.dumps(calculation_plan, cls=PartSegEncoder, indent=2).split("\n")
         for i in range(math.ceil(len(calculation_plan_pretty) / MAX_ROWS_IN_EXCEL_CELL)):
             to_write = calculation_plan_pretty[i * MAX_ROWS_IN_EXCEL_CELL : (i + 1) * MAX_ROWS_IN_EXCEL_CELL]
-            sheet.write(f"C{i+2}", "\n".join(to_write))
+            sheet.write(f"C{i + 2}", "\n".join(to_write))
             sheet.set_row(i + 1, len(to_write) * 11 + 10)
 
         sheet.set_column(2, 2, max(map(len, calculation_plan_pretty)))

--- a/package/PartSegCore/analysis/measurement_calculation.py
+++ b/package/PartSegCore/analysis/measurement_calculation.py
@@ -1447,9 +1447,7 @@ class SplitOnPartVolume(MeasurementMethodBase):
     __argument_class__ = SplitOnPartParameters
 
     @staticmethod
-    def calculate_property(
-        part_selection, area_array, voxel_size, result_scalar, **kwargs
-    ):  # pylint: disable=arguments-differ
+    def calculate_property(part_selection, area_array, voxel_size, result_scalar, **kwargs):  # pylint: disable=arguments-differ
         masked = MaskDistanceSplit.split(voxel_size=voxel_size, **kwargs)
         mask = masked == part_selection
         return np.count_nonzero(mask * area_array) * pixel_volume(voxel_size, result_scalar)

--- a/package/PartSegCore/class_generator.py
+++ b/package/PartSegCore/class_generator.py
@@ -308,8 +308,7 @@ class BaseMeta(type):
                 defaults_dict[field_name] = default_value
             elif defaults:
                 raise TypeError(
-                    "Non-default namedtuple field {field_name} cannot "
-                    "follow default field(s) {default_names}".format(
+                    "Non-default namedtuple field {field_name} cannot follow default field(s) {default_names}".format(
                         field_name=field_name, default_names=", ".join(defaults_dict.keys())
                     )
                 )

--- a/package/PartSegCore/sphinx/auto_parameters.py
+++ b/package/PartSegCore/sphinx/auto_parameters.py
@@ -50,7 +50,7 @@ class RegisterDocumenter(ModuleLevelDocumenter):
         k = 0
         if self.object.methods:
             self.add_line(
-                f'Need methods: {", ".join(f"``{x}``" for x in self.object.methods)}',
+                f"Need methods: {', '.join(f'``{x}``' for x in self.object.methods)}",
                 source,
                 k,
             )
@@ -59,7 +59,7 @@ class RegisterDocumenter(ModuleLevelDocumenter):
             k += 2
         if self.object.class_methods:
             self.add_line(
-                f'Need class methods: {", ".join(f"``{x}``" for x in self.object.class_methods)}',
+                f"Need class methods: {', '.join(f'``{x}``' for x in self.object.class_methods)}",
                 source,
                 k,
             )

--- a/package/PartSegImage/image.py
+++ b/package/PartSegImage/image.py
@@ -284,7 +284,7 @@ class Image:
 
         res = [
             ChannelInfoFull(
-                name=ch_inf.name or f"channel {i+1}",
+                name=ch_inf.name or f"channel {i + 1}",
                 color_map=(
                     ch_inf.color_map if ch_inf.color_map is not None else next(default_colors)  # skipcq: PTC-W0063
                 ),
@@ -298,7 +298,7 @@ class Image:
         ]
         res.extend(
             ChannelInfoFull(
-                name=f"channel {i+1}",
+                name=f"channel {i + 1}",
                 color_map=next(default_colors),  # skipcq: PTC-W0063
                 contrast_limits=(np.min(arr), np.max(arr)),
             )
@@ -919,7 +919,6 @@ class Image:
         """
         res = []
         for color in self.default_coloring:
-
             if isinstance(color, str):
                 if color.startswith("#"):
                     color_array = _hex_to_rgb(color)

--- a/package/tests/test_PartSeg/test_common_gui.py
+++ b/package/tests/test_PartSeg/test_common_gui.py
@@ -1518,7 +1518,6 @@ def test_collapsable(qtbot):
 
 
 def test_multiple_files_tree_widget(qtbot, monkeypatch):
-
     def _monkey_qmenu(func):
         res = QMenu()
         monkeypatch.setattr(res, "exec_", partial(func, res))
@@ -1597,7 +1596,6 @@ def test_exception_hooks_other_exception():
 
 
 def test_update_dict():
-
     assert recursive_update({}, {}) == {}
     assert recursive_update(None, {}) == {}
     assert recursive_update(None, {"a": 1}) == {"a": 1}
@@ -1608,7 +1606,6 @@ def test_update_dict():
 
 
 def test_pretty_print():
-
     assert _pretty_print({"a": 1}) == "\n  a: 1"
     assert _pretty_print({"a": 1}, indent=0) == "\na: 1"
     assert _pretty_print({"a": {"a": 1}}) == "\n  a: \n    a: 1"
@@ -1650,7 +1647,6 @@ class TestBaseAlgorithmSettingsWidget:
         ],
     )
     def test_exception_occurred(self, monkeypatch, exc, expected, qtbot):
-
         called = False
 
         def _exec(self):
@@ -1663,7 +1659,6 @@ class TestBaseAlgorithmSettingsWidget:
         assert called
 
     def test_exception_occurred_other_exception(self, monkeypatch, qtbot):
-
         called = False
 
         def _exec(self):

--- a/package/tests/test_PartSeg/test_sentry.py
+++ b/package/tests/test_PartSeg/test_sentry.py
@@ -155,7 +155,6 @@ def executor_fun(que: multiprocessing.Queue):
 
 
 def test_exception_pass(monkeypatch):
-
     done = [False]
 
     def check_event(envelope):

--- a/package/tests/test_PartSegCore/test_algorithm_describe_base.py
+++ b/package/tests/test_PartSegCore/test_algorithm_describe_base.py
@@ -566,7 +566,6 @@ class TestROIExtractionProfile:
         assert prof.dict()["values"]["threshold"]["values"]["threshold"] == 8000
 
     def test_pretty_print(self):
-
         prof1 = ROIExtractionProfile(name="aaa", algorithm="Lower threshold", values={})
         assert prof1.pretty_print(AnalysisAlgorithmSelection).startswith("ROI extraction profile name:")
         prof1 = ROIExtractionProfile(name="", algorithm="Lower threshold", values={})

--- a/package/tests/test_PartSegCore/test_analysis_batch.py
+++ b/package/tests/test_PartSegCore/test_analysis_batch.py
@@ -545,7 +545,7 @@ class TestCalculationProcess:
         df = pd.read_excel(os.path.join(tmpdir, "test.xlsx"), index_col=0, header=[0, 1], engine=ENGINE)
         assert df.shape == (8, 4)
         for i in range(8):
-            assert os.path.basename(df.name.units[i]) == f"stack1_component{i+1}.tif"
+            assert os.path.basename(df.name.units[i]) == f"stack1_component{i + 1}.tif"
 
     @pytest.mark.filterwarnings("ignore:This method will be removed")
     def test_full_pipeline_long(self, tmpdir, data_test_dir, monkeypatch, calculation_plan_long):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,34 +260,24 @@ exclude_also = [
     "if typing.TYPE_CHECKING:",
 ]
 
-[tool.black]
-line-length = 120
-target-version = ['py39']
-include = '\.pyi?$'
-exclude = '''
-
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-  )/
-  | foo.py           # also separately exclude a file named foo.py in
-                     # the root of the project
-  | package/PartSeg/version.py
-)
-'''
 
 [tool.ruff]
 line-length = 120
-exclude = ["examples/call_simple_threshold.py"]
+exclude = [
+    "examples/call_simple_threshold.py",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".tox",
+    ".venv",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "foo.py",
+    "package/PartSeg/version.py",
+]
 target-version = "py39"
 fix = true
 

--- a/tutorials/tutorial_neuron_types/Neuron_types_example.ipynb
+++ b/tutorials/tutorial_neuron_types/Neuron_types_example.ipynb
@@ -56,14 +56,14 @@
     "\n",
     "!pip install PartSeg\n",
     "\n",
-    "#download data\n",
+    "# download data\n",
     "import urllib.request\n",
     "import zipfile\n",
     "\n",
     "zip_file_path, _ = urllib.request.urlretrieve(\"https://bokota.pl/typy_neuronow2.zip\")\n",
     "with open(zip_file_path, \"rb\") as ff:\n",
     "    z_file = zipfile.ZipFile(ff)\n",
-    "    z_file.extractall()\n"
+    "    z_file.extractall()"
    ]
   },
   {
@@ -161,16 +161,17 @@
    "source": [
     "from PartSegCore.segmentation.noise_filtering import DimensionType\n",
     "\n",
-    "parameters2 = {\"channel\": 3,\n",
-    " \"threshold\": {\"name\": \"Manual\", \"values\": {\"threshold\": 19000}},\n",
-    " \"minimum_size\": 8000,\n",
-    " \"close_holes\": True,\n",
-    " \"close_holes_size\": 200,\n",
-    " \"smooth_border\": {\"name\": \"None\", \"values\": {}},\n",
-    " \"noise_filtering\": {\"name\": \"Gauss\",\n",
-    " \"values\": {\"dimension_type\": DimensionType.Layer, \"radius\": 1.0}},\n",
-    " \"side_connection\": False,\n",
-    " \"use_convex\": True}"
+    "parameters2 = {\n",
+    "    \"channel\": 3,\n",
+    "    \"threshold\": {\"name\": \"Manual\", \"values\": {\"threshold\": 19000}},\n",
+    "    \"minimum_size\": 8000,\n",
+    "    \"close_holes\": True,\n",
+    "    \"close_holes_size\": 200,\n",
+    "    \"smooth_border\": {\"name\": \"None\", \"values\": {}},\n",
+    "    \"noise_filtering\": {\"name\": \"Gauss\", \"values\": {\"dimension_type\": DimensionType.Layer, \"radius\": 1.0}},\n",
+    "    \"side_connection\": False,\n",
+    "    \"use_convex\": True,\n",
+    "}"
    ]
   },
   {
@@ -288,7 +289,7 @@
     "    volume = Volume.calculate_property(current_component_area, voxel_size=image.spacing, result_scalar=10**6)\n",
     "    # calculate shericity\n",
     "    # print(component_number, (4/3 * pi * (diameter/2)**3)/volume, diameter)\n",
-    "    if (4/3 * pi * (diameter/2)**3)/volume > 4:\n",
+    "    if (4 / 3 * pi * (diameter / 2) ** 3) / volume > 4:\n",
     "        continue\n",
     "    good_neurons.append(component_number)\n",
     "print(good_neurons)"
@@ -322,7 +323,7 @@
     "    value_red = np.percentile(image.get_channel(0)[0][current_component_area], 75)\n",
     "    # radius is 3, 9, 9 because voxel size is 210x70x70nm and voxel size is in pixels, not physicla units\n",
     "    dilate_sitk = sitk.BinaryContour(sitk.GetImageFromArray(current_component_area.astype(np.uint8)))\n",
-    "    dilate_mask = sitk.GetArrayFromImage(sitk.BinaryDilate(dilate_sitk, (3, 9 ,9)))\n",
+    "    dilate_mask = sitk.GetArrayFromImage(sitk.BinaryDilate(dilate_sitk, (3, 9, 9)))\n",
     "    # dilate_mask = dilate(current_component_area, (3, 9 ,9), False) # slower than two above lines but combined with next gave same result\n",
     "    dilate_mask[current_component_area] = 0\n",
     "    value_green = np.percentile(image.get_channel(1)[0][current_component_area], 75)\n",
@@ -338,8 +339,7 @@
     "        neuron_type_dict[\"pyramidal\"].append(component_number)\n",
     "        continue\n",
     "    neuron_type_dict[\"inhibitory\"].append(component_number)\n",
-    "print(neuron_type_dict)\n",
-    "\n"
+    "print(neuron_type_dict)"
    ]
   },
   {
@@ -406,10 +406,7 @@
     "        if np.min(coords) == 0:\n",
     "            continue\n",
     "        touch = any(\n",
-    "            np.max(axis_cords) == max_size - 1\n",
-    "            for axis_cords, max_size in zip(\n",
-    "                coords, current_component_area.shape\n",
-    "            )\n",
+    "            np.max(axis_cords) == max_size - 1 for axis_cords, max_size in zip(coords, current_component_area.shape)\n",
     "        )\n",
     "\n",
     "        if touch:\n",
@@ -418,11 +415,12 @@
     "        volume = Volume.calculate_property(current_component_area, voxel_size=image.spacing, result_scalar=1)\n",
     "        # calculate\n",
     "        # print(component_number, (4/3 * pi * (diameter/2)**3)/volume, diameter)\n",
-    "        if (4/3 * pi * (diameter/2)**3)/volume > 4.5:\n",
+    "        if (4 / 3 * pi * (diameter / 2) ** 3) / volume > 4.5:\n",
     "            continue\n",
     "        good_neurons.append(component_number)\n",
     "    print(f\"filtered {segmentation.max() - len(good_neurons)}\")\n",
     "    return set(good_neurons)\n",
+    "\n",
     "\n",
     "def classify_neurons(image: Image, segmentation: np.ndarray, good_neurons: set):\n",
     "    neuron_type_dict = defaultdict(list)\n",
@@ -435,7 +433,7 @@
     "        value_red = np.percentile(image.get_channel(0)[0][current_component_area], 75)\n",
     "        # radius is 3, 9, 9 because voxel size is 210x70x70nm and voxel size is in pixels, not physicla units\n",
     "        dilate_sitk = sitk.BinaryContour(sitk.GetImageFromArray(current_component_area.astype(np.uint8)))\n",
-    "        dilate_mask = sitk.GetArrayFromImage(sitk.BinaryDilate(dilate_sitk, (3, 9 ,9)))\n",
+    "        dilate_mask = sitk.GetArrayFromImage(sitk.BinaryDilate(dilate_sitk, (3, 9, 9)))\n",
     "        # dilate_mask = dilate(current_component_area, (3, 9 ,9), False) # slower than two above lines but combined with next gave same result\n",
     "        dilate_mask[current_component_area] = 0\n",
     "        value_green = np.percentile(image.get_channel(1)[0][current_component_area], 75)\n",
@@ -457,9 +455,11 @@
     "    # print(neuron_type_dict)\n",
     "    return neuron_type_dict\n",
     "\n",
+    "\n",
     "def segmentation_function(path_to_file, segment_object):\n",
     "    def empty(_x, _y):\n",
     "        pass\n",
+    "\n",
     "    image = TiffImageReader.read_image(path_to_file)\n",
     "    segment_object.set_image(image)\n",
     "    result = segment_object.calculation_run(empty)\n",
@@ -496,8 +496,7 @@
     "\n",
     "for file_path in glob(os.path.join(data_path, \"*.lsm\")):\n",
     "    print(\"process\", os.path.basename(file_path))\n",
-    "    cutted_neurons_dict[file_path] = segmentation_function(file_path, segment)\n",
-    "\n"
+    "    cutted_neurons_dict[file_path] = segmentation_function(file_path, segment)"
    ]
   },
   {
@@ -550,6 +549,8 @@
    "source": [
     "def empty(_x, _y):\n",
     "    pass\n",
+    "\n",
+    "\n",
     "measurment_dict = defaultdict(list)\n",
     "for nucleus_group_dict in cutted_neurons_dict.values():\n",
     "    for nucleus_type, nucleus_list in nucleus_group_dict.items():\n",
@@ -558,8 +559,7 @@
     "            neuron_segment.set_mask(nucleus.mask[0])  # do not touch time\n",
     "            neuron_segment.set_parameters(neuron_segmentation_profile.values)\n",
     "            result = neuron_segment.calculation_run(empty)\n",
-    "            measurment_dict[nucleus_type].append(\n",
-    "                measurment_object.calculate(nucleus, 2 , result.roi, Units.nm))\n"
+    "            measurment_dict[nucleus_type].append(measurment_object.calculate(nucleus, 2, result.roi, Units.nm))"
    ]
   },
   {
@@ -585,14 +585,14 @@
    "source": [
     "ticks, values = list(zip(*measurment_result))\n",
     "values = list(zip(*values))\n",
-    "f, axx = plt.subplots(1, len(values), figsize=(5 * len(values),5))\n",
+    "f, axx = plt.subplots(1, len(values), figsize=(5 * len(values), 5))\n",
     "for el, ax in zip(values, axx):\n",
     "    name, mean, std = list(zip(*el))\n",
     "    plt.sca(ax)\n",
     "    plt.title(name[0])\n",
     "    plt.bar(range(len(ticks)), mean)\n",
     "    for i, m, s in zip(range(len(mean)), mean, std):\n",
-    "        plt.plot([i, i], [m - s/2, m + s/2], color=\"black\")\n",
+    "        plt.plot([i, i], [m - s / 2, m + s / 2], color=\"black\")\n",
     "    plt.xticks(range(len(ticks)), ticks)"
    ]
   },
@@ -665,7 +665,7 @@
     "\n",
     "layer_num = 28\n",
     "layer = image_app.get_data_by_axis(t=0, z=layer_num)\n",
-    "components_to_show = np.ones(segmentation_app.max()+1, dtype=np.uint8)\n",
+    "components_to_show = np.ones(segmentation_app.max() + 1, dtype=np.uint8)\n",
     "colormaps_list = [default_colormap_dict.get(x, None) for x in [\"red\", \"green\", \"blue\", None]]\n",
     "\n",
     "colored_image = color_image_fun(layer, colors=colormaps_list, min_max=image_app.get_ranges())\n",
@@ -702,7 +702,7 @@
     "    colored_stack.append(colored_image)\n",
     "colored_array = np.stack(colored_stack)\n",
     "tifffile.imshow(colored_array)\n",
-    "plt.show()\n"
+    "plt.show()"
    ]
   },
   {
@@ -725,7 +725,7 @@
     "\n",
     "from PartSegCore.mask.io_functions import MaskProjectTuple, SaveROI\n",
     "from PartSegCore.segmentation.segmentation_algorithm import ThresholdAlgorithm\n",
-    "from PartSegImage.image_reader import TiffImageReader\n"
+    "from PartSegImage.image_reader import TiffImageReader"
    ]
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Replace Black with Ruff as the project’s code formatter and reformat the entire codebase accordingly

Enhancements:
- Switch code formatter from Black to Ruff and configure Ruff settings in pyproject.toml
- Reformat Python modules, notebooks, and tests to conform with Ruff style rules (operator spacing, blank lines, f-string formatting)

CI:
- Remove Black pre-commit hooks and add Ruff check and format hooks in .pre-commit-config.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated code formatting toolchain from Black to Ruff for improved consistency and performance.
  * Updated Markdown formatting dependencies with additional plugins for enhanced documentation processing.
  * Expanded development tool exclusion rules to cover more standard build and cache directories.
  * Applied code style standardization across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->