### PR TITLE
chore: Drop macOs-13 on Azure Pipelines, fix parameter name for pyinstaller template

### DIFF
--- a/.azure-pipelines/pyinstaller.yaml
+++ b/.azure-pipelines/pyinstaller.yaml
@@ -1,5 +1,5 @@
 parameters:
-- name: test_path # name of the parameter; required
+- name: test_command # name of the parameter; required
   type: string # data type of the parameter; required
 - name: cache_dir # name of the parameter; required
   type: string
@@ -23,5 +23,5 @@ steps:
     inputs:
       targetPath: dist2
       publishLocation: pipeline
-  - script: ${{ parameters.test_path }}
+  - script: ${{ parameters.test_command }}
     displayName: TestBuild

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,7 +160,7 @@ stages:
 
       - job: pyinstaller_linux
         variables:
-          test_path: dist/PartSeg/PartSeg _test
+          test_command: dist/PartSeg/PartSeg _test
           DISPLAY: ':99.0'
           pip_cache_dir: $(Pipeline.Workspace)/.pip
         pool: { vmImage: 'Ubuntu-22.04' }
@@ -168,7 +168,7 @@ stages:
           - template: .azure-pipelines/linux_libs.yaml
           - template: .azure-pipelines/pyinstaller.yaml
             parameters:
-              test_path: $(test_path)
+              test_command: $(test_command)
               cache_dir: $(pip_cache_dir)
 
       - job: pyinstaller
@@ -177,15 +177,15 @@ stages:
           matrix:
             macos:
               imageName: 'macos-14'
-              test_path: dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test
+              test_command: dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test
             windows:
               imageName: 'windows-2022'
-              test_path: dist\PartSeg\PartSeg _test
+              test_command: dist\PartSeg\PartSeg _test
         variables:
           pip_cache_dir: $(Pipeline.Workspace)/.pip
         pool: {vmImage: $(imageName)}
         steps:
           - template: .azure-pipelines/pyinstaller.yaml
             parameters:
-              test_path: $(test_path)
+              test_command: $(test_command)
               cache_dir: $(pip_cache_dir)


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch Azure Pipelines macOS jobs from the macos-13 image to macos-14 and consolidate the macOS matrix entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline macOS build and test configurations to use a newer macOS image.
  * Standardized the test invocation parameter across pipeline templates to ensure consistent test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->