### PR TITLE
chore: Update runners in make-release workflow

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-2022", "macos-13", "macos-14"]
+        os: ["ubuntu-22.04", "windows-2022", "macos-15-intel", "macos-15"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust the GitHub Actions make-release workflow matrix to target macos-15-intel and macos-15 runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use newer macOS runner versions for improved compatibility and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->