### PR TITLE
chore: accept `time` argument in `not_start` mock of timer `start`

### DIFF
--- a/package/tests/test_PartSeg/conftest.py
+++ b/package/tests/test_PartSeg/conftest.py
@@ -90,7 +90,7 @@ def _block_threads(monkeypatch, request):
             else:
                 old_start(self)
 
-    def not_start(self):
+    def not_start(self, time=None):
         raise RuntimeError("Thread should not be used in test")
 
     monkeypatch.setattr(QTimer, "start", not_start)


### PR DESCRIPTION
To improve readability of the stack trace, accept the `time` argument.

## Summary by Sourcery

Tests:
- Update the not_start QTimer.start test mock to accept an optional time parameter without changing its failure behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed test configuration to properly handle optional parameters, improving test execution reliability and preventing argument mismatch errors during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->