### PR TITLE
fix: Fix `QtViewer` initialization as preparation for napari 0.7.0

### DIFF
--- a/.github/project_dict.pws
+++ b/.github/project_dict.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 22
+personal_ws-1.1 en 29
 napari
 autoupdate
 aspell
@@ -27,3 +27,4 @@ cooldown
 otsu
 ome
 ImageJ
+QtViewer

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -936,7 +936,10 @@ class ImageView(QWidget):
 class NapariQtViewer(QtViewer):
     def __init__(self, viewer):
         super().__init__(viewer, show_welcome_screen=False)
-        self.widget(0).layout().setContentsMargins(0, 5, 0, 2)
+        layout = self.widget(0).layout()
+        if layout is not None:
+            # Before napari 0.7.0
+            layout.setContentsMargins(0, 5, 0, 2)
 
     def dragEnterEvent(self, event):  # pylint: disable=no-self-use
         """


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent errors during NapariQtViewer initialization when the underlying widget has no layout in newer napari versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a stability issue in the image viewer that could cause errors when the interface layout is unavailable.

* **Chores**
  * Updated internal reference data and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->