### PR TITLE
chore: Drop test against pyside2, fix test for napari 0.7.0, add testing against python 3.13

### DIFF
--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Test with tox PartSegImage
         if: ${{ inputs.napari == 'latest' }}
+        shell: bash
+        # shellcheck disable=SC2086
         run: python -m tox $TOX_ARGS -- package/tests/test_PartSegImage $PYTEST_ARGS
         env:
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
@@ -94,6 +96,8 @@ jobs:
 
       - name: Test with tox PartSegCore
         if: ${{ inputs.napari == 'latest' }}
+        shell: bash
+        # shellcheck disable=SC2086
         run: python -m tox $TOX_ARGS --  package/tests/test_PartSegCore $PYTEST_ARGS
         env:
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
@@ -102,6 +106,8 @@ jobs:
       - name: Test with tox PartSeg
         if: ${{ inputs.napari == 'latest' }}
         timeout-minutes: ${{ inputs.timeout }}
+        shell: bash
+        # shellcheck disable=SC2086
         run: python -m tox $TOX_ARGS -- package/tests/test_PartSeg $PYTEST_ARGS
         env:
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
@@ -110,6 +116,8 @@ jobs:
       - name: Test with tox all
         if: ${{ inputs.napari != 'latest' }}
         timeout-minutes: ${{ inputs.timeout }}
+        shell: bash
+        # shellcheck disable=SC2086
         run: python -m tox $TOX_ARGS ${PYTEST_ARGS:+-- $PYTEST_ARGS}
         env:
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}

--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -67,20 +67,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'pyproject.toml'
 
-#      - name: Install ubuntu libraries
-#        if: runner.os == 'Linux'
-#        run: |
-#          sudo apt update
-#          sudo apt-get install -y libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0
-
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        if: runner.os == 'Linux'
+      - name: Setup headless display
+        uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2
         with:
-          packages: libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libhdf5-dev
-          version: 1.0
-
-      - name: Install Windows OpenGL
-        uses: pyvista/setup-headless-display-action@v4
+          qt: true
+          wm: herbstluftwm
 
       - name: Download test data
         if: ${{ inputs.test_data }}
@@ -110,20 +101,16 @@ jobs:
 
       - name: Test with tox PartSeg
         if: ${{ inputs.napari == 'latest' }}
-        uses: aganders3/headless-gui@v2
         timeout-minutes: ${{ inputs.timeout }}
-        with:
-          run: python -m tox $TOX_ARGS -- package/tests/test_PartSeg $PYTEST_ARGS
+        run: python -m tox $TOX_ARGS -- package/tests/test_PartSeg $PYTEST_ARGS
         env:
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
 
       - name: Test with tox all
         if: ${{ inputs.napari != 'latest' }}
-        uses: aganders3/headless-gui@v2
         timeout-minutes: ${{ inputs.timeout }}
-        with:
-          run: python -m tox $TOX_ARGS ${PYTEST_ARGS:+-- $PYTEST_ARGS}
+        run: python -m tox $TOX_ARGS ${PYTEST_ARGS:+-- $PYTEST_ARGS}
         env:
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}

--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -88,8 +88,9 @@ jobs:
       - name: Test with tox PartSegImage
         if: ${{ inputs.napari == 'latest' }}
         shell: bash
-        # shellcheck disable=SC2086
-        run: python -m tox $TOX_ARGS -- package/tests/test_PartSegImage $PYTEST_ARGS
+        run: |
+          # shellcheck disable=SC2086
+          python -m tox $TOX_ARGS -- package/tests/test_PartSegImage $PYTEST_ARGS
         env:
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
@@ -97,8 +98,9 @@ jobs:
       - name: Test with tox PartSegCore
         if: ${{ inputs.napari == 'latest' }}
         shell: bash
-        # shellcheck disable=SC2086
-        run: python -m tox $TOX_ARGS --  package/tests/test_PartSegCore $PYTEST_ARGS
+        run: |
+          # shellcheck disable=SC2086
+          python -m tox $TOX_ARGS --  package/tests/test_PartSegCore $PYTEST_ARGS
         env:
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
@@ -107,8 +109,9 @@ jobs:
         if: ${{ inputs.napari == 'latest' }}
         timeout-minutes: ${{ inputs.timeout }}
         shell: bash
-        # shellcheck disable=SC2086
-        run: python -m tox $TOX_ARGS -- package/tests/test_PartSeg $PYTEST_ARGS
+        run: |
+          # shellcheck disable=SC2086
+          python -m tox $TOX_ARGS -- package/tests/test_PartSeg $PYTEST_ARGS
         env:
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
@@ -117,8 +120,9 @@ jobs:
         if: ${{ inputs.napari != 'latest' }}
         timeout-minutes: ${{ inputs.timeout }}
         shell: bash
-        # shellcheck disable=SC2086
-        run: python -m tox $TOX_ARGS ${PYTEST_ARGS:+-- $PYTEST_ARGS}
+        run: |
+          # shellcheck disable=SC2086
+          python -m tox $TOX_ARGS ${PYTEST_ARGS:+-- $PYTEST_ARGS}
         env:
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}

--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -123,9 +123,8 @@ jobs:
         uses: aganders3/headless-gui@v2
         timeout-minutes: ${{ inputs.timeout }}
         with:
-          run: python -m tox $TOX_ARGS $PYTEST_ARGS
+          run: python -m tox $TOX_ARGS ${PYTEST_ARGS:+-- $PYTEST_ARGS}
         env:
-          PYTEST_ARGS: ${{ inputs.pytest_args != '' && format('-- {0}', inputs.pytest_args) || '' }}
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
 

--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -52,6 +52,12 @@ jobs:
   test:
     name: ${{ inputs.os }} py ${{ inputs.python_version }} ${{ inputs.napari }} ${{ inputs.qt_backend }} ${{ inputs.pydantic }}
     runs-on: ${{ inputs.os }}
+    env:
+      NAPARI: ${{ inputs.napari }}
+      BACKEND: ${{ inputs.qt_backend }}
+      PYVISTA_OFF_SCREEN: True  # required for opengl on windows
+      TOX_ARGS: ${{ inputs.tox_args }}
+      PYTEST_ARGS: ${{ inputs.pytest_args }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -90,21 +96,15 @@ jobs:
 
       - name: Test with tox PartSegImage
         if: ${{ inputs.napari == 'latest' }}
-        run: python -m tox ${{ inputs.tox_args }} -- package/tests/test_PartSegImage ${{ inputs.pytest_args }}
+        run: python -m tox $TOX_ARGS -- package/tests/test_PartSegImage $PYTEST_ARGS
         env:
-          PYVISTA_OFF_SCREEN: True  # required for opengl on windows
-          NAPARI: ${{ inputs.napari }}
-          BACKEND: ${{ inputs.qt_backend }}
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
 
       - name: Test with tox PartSegCore
         if: ${{ inputs.napari == 'latest' }}
-        run: python -m tox ${{ inputs.tox_args }} --  package/tests/test_PartSegCore ${{ inputs.pytest_args }}
+        run: python -m tox $TOX_ARGS --  package/tests/test_PartSegCore $PYTEST_ARGS
         env:
-          PYVISTA_OFF_SCREEN: True  # required for opengl on windows
-          NAPARI: ${{ inputs.napari }}
-          BACKEND: ${{ inputs.qt_backend }}
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
 
@@ -113,11 +113,8 @@ jobs:
         uses: aganders3/headless-gui@v2
         timeout-minutes: ${{ inputs.timeout }}
         with:
-          run: python -m tox ${{ inputs.tox_args }} -- package/tests/test_PartSeg ${{ inputs.pytest_args }}
+          run: python -m tox $TOX_ARGS -- package/tests/test_PartSeg $PYTEST_ARGS
         env:
-          PYVISTA_OFF_SCREEN: True  # required for opengl on windows
-          NAPARI: ${{ inputs.napari }}
-          BACKEND: ${{ inputs.qt_backend }}
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
 
@@ -126,11 +123,9 @@ jobs:
         uses: aganders3/headless-gui@v2
         timeout-minutes: ${{ inputs.timeout }}
         with:
-          run: python -m tox ${{ inputs.tox_args }} ${{ inputs.pytest_args != '' && format('-- {0}', inputs.pytest_args) || '' }}
+          run: python -m tox $TOX_ARGS $PYTEST_ARGS
         env:
-          PYVISTA_OFF_SCREEN: True  # required for opengl on windows
-          NAPARI: ${{ inputs.napari }}
-          BACKEND: ${{ inputs.qt_backend }}
+          PYTEST_ARGS: ${{ inputs.pytest_args != '' && format('-- {0}', inputs.pytest_args) || '' }}
           PIP_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}{1}.txt', inputs.python_version, inputs.pydantic ) || 'requirements/version_denylist.txt' }}
 

--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -126,7 +126,7 @@ jobs:
         uses: aganders3/headless-gui@v2
         timeout-minutes: ${{ inputs.timeout }}
         with:
-          run: python -m tox ${{ inputs.tox_args }} -- ${{ inputs.pytest_args }}
+          run: python -m tox ${{ inputs.tox_args }} ${{ inputs.pytest_args != '' && format('-- {0}', inputs.pytest_args) || '' }}
         env:
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           NAPARI: ${{ inputs.napari }}

--- a/.github/workflows/test_napari_repo.yml
+++ b/.github/workflows/test_napari_repo.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ ubuntu-24.04 ]
-        python: ['3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12', '3.13']
         napari_version: ['repo']
     steps:
       - uses: actions/checkout@v6

--- a/package/PartSeg/common_gui/main_window.py
+++ b/package/PartSeg/common_gui/main_window.py
@@ -227,10 +227,13 @@ class BaseMainWindow(QMainWindow):
         return [self.settings.colormap_dict[name][0] for name in colormaps_name]
 
     def napari_viewer_show(self):
-        viewer = Viewer(title="Additional output", settings=self.settings, partseg_viewer_name=self.channel_info)
+        viewer = Viewer(
+            title="Additional output", settings=self.settings, partseg_viewer_name=self.channel_info, show=False
+        )
         viewer.scale_bar.unit = "nm"
         viewer.theme = self.settings.theme_name
         viewer.create_initial_layers(image=True, roi=True, additional_layers=False, points=True)
+        viewer.show()
         self.viewer_list.append(viewer)
         viewer.window.qt_viewer.destroyed.connect(lambda _x: self.close_viewer(viewer))
 

--- a/package/PartSeg/common_gui/main_window.py
+++ b/package/PartSeg/common_gui/main_window.py
@@ -241,9 +241,12 @@ class BaseMainWindow(QMainWindow):
         if not self.settings.additional_layers:
             QMessageBox().information(self, "No data", "Last executed algorithm does not provide additional data")
             return
-        viewer = Viewer(title="Additional output", settings=self.settings, partseg_viewer_name=self.channel_info)
+        viewer = Viewer(
+            title="Additional output", settings=self.settings, partseg_viewer_name=self.channel_info, show=False
+        )
         viewer.theme = self.settings.theme_name
         viewer.create_initial_layers(image=with_channels, roi=False, additional_layers=True, points=False)
+        viewer.show()
         self.viewer_list.append(viewer)
         viewer.window.qt_viewer.destroyed.connect(lambda _x: self.close_viewer(viewer))
 

--- a/package/tests/test_PartSeg/test_viewer.py
+++ b/package/tests/test_PartSeg/test_viewer.py
@@ -73,7 +73,7 @@ class TestNapariViewer:
     def test_base(self, image, analysis_segmentation2, tmp_path):
         settings = BaseSettings(tmp_path)
         settings.image = image
-        viewer = Viewer(settings, "")
+        viewer = Viewer(settings, "", show=False)
         viewer.create_initial_layers(True, True, True, True)
         assert len(viewer.layers) == 2
         viewer.create_initial_layers(True, True, True, True)
@@ -92,7 +92,7 @@ class TestNapariViewer:
     def test_points(self, image, tmp_path, qtbot):
         settings = BaseSettings(tmp_path)
         settings.image = image
-        viewer = Viewer(settings, "")
+        viewer = Viewer(settings, "", show=False)
         viewer.create_initial_layers(True, True, True, True)
         assert len(viewer.layers) == 2
         points = np.array([[0, 1, 1, 1], [0, 7, 10, 10]])
@@ -113,7 +113,7 @@ class TestNapariViewer:
     def test_image(self, image, image2, tmp_path, qtbot):
         settings = BaseSettings(tmp_path)
         settings.image = image
-        viewer = Viewer(settings, "test")
+        viewer = Viewer(settings, "test", show=False)
         with qtbot.waitSignal(viewer._sync_widget.sync_image_chk.stateChanged):
             viewer._sync_widget.sync_image_chk.setChecked(True)
         assert len(viewer.layers) == 2
@@ -125,7 +125,7 @@ class TestNapariViewer:
     def test_roi(self, image, tmp_path, qtbot):
         settings = BaseSettings(tmp_path)
         settings.image = image
-        viewer = Viewer(settings, "test")
+        viewer = Viewer(settings, "test", show=False)
         viewer._sync_widget.sync_image()
         assert len(viewer.layers) == 2
         viewer._sync_widget.sync_ROI_chk.setChecked(True)
@@ -135,10 +135,11 @@ class TestNapariViewer:
         assert len(viewer.layers) == 4
         viewer.close()
 
-    def test_additional(self, image, tmp_path, qtbot):
+    @pytest.mark.usefixtures("qtbot")
+    def test_additional(self, image, tmp_path):
         settings = BaseSettings(tmp_path)
         settings.image = image
-        viewer = Viewer(settings, "test")
+        viewer = Viewer(settings, "test", show=False)
         viewer._sync_widget.sync_image()
         assert len(viewer.layers) == 2
         settings._additional_layers = {

--- a/tox.ini
+++ b/tox.ini
@@ -71,15 +71,23 @@ deps=
     pytest-json-report
     lxml_html_clean
 
-[testenv:py{39,310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-napari_{419,54,repo}]
+
+[testenv:py{39,310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-napari_{419,54}]
 deps =
     {[testenv]deps}
     napari_419: napari==0.4.19.post1
     napari_54: napari==0.5.4
-    napari_repo: git+https://github.com/napari/napari.git
 commands =
-    !napari_repo: python -m pytest -v package/tests/test_PartSeg/test_napari_widgets.py --json-report --json-report-file={toxinidir}/report-{envname}-{sys_platform}.json {posargs}
-    napari_repo: python -m pytest package/tests --json-report --json-report-file={toxinidir}/report-{envname}-{sys_platform}.json {posargs}
+    python -m pytest -v package/tests/test_PartSeg/test_napari_widgets.py --json-report --json-report-file={toxinidir}/report-{envname}-{sys_platform}.json {posargs}
+
+
+[testenv:py{310,311,312,313}-{PyQt5,PyQt6,PySide6}-napari_repo]
+deps =
+    {[testenv]deps}
+    git+https://github.com/napari/napari.git
+commands =
+    python -m pytest package/tests --json-report --json-report-file={toxinidir}/report-{envname}-{sys_platform}.json {posargs}
+
 
 [testenv:py{39,310,311,312,313}-PyQt5-coverage]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{39,310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-all, py{310,311,312,313}-{PyQt5,PyQt6}-napari_repo,py{39,310,311,312,313}-{PyQt5,PyQt6,Pyside2}-napari_{419,54} , py{312,313}-PySide6-napari_{419,54,repo}
+envlist = py{39,310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-all, py{310,311,312,313}-{PyQt5,PyQt6}-napari_repo,py{39,310,311,312,313}-{PyQt5,PyQt6,PySide2}-napari_{419,54}, py{312,313}-PySide6-napari_{419,54,repo}
 toxworkdir=/tmp/tox
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{39,310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-all, py{39,310,311,312,313}-{PyQt5,PyQt6}-napari_{419,54,repo}, py{39,310}-PySide2-napari_{419,54,repo}
+envlist = py{39,310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-all, py{39,310,311,312,313}-{PyQt5,PyQt6}-napari_{419,54,repo}, py{312,313}-PySide6-napari_{419,54,repo}
 toxworkdir=/tmp/tox
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{39,310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-all, py{310,311,312,313}-{PyQt5,PyQt6}-napari_{419,54,repo},py39-{PyQt5,PyQt6}-napari_{419,54} , py{312,313}-PySide6-napari_{419,54,repo}
+envlist = py{39,310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-all, py{310,311,312,313}-{PyQt5,PyQt6}-napari_repo,py{39,310,311,312,313}-{PyQt5,PyQt6,Pyside2}-napari_{419,54} , py{312,313}-PySide6-napari_{419,54,repo}
 toxworkdir=/tmp/tox
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{39,310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-all, py{39,310,311,312,313}-{PyQt5,PyQt6}-napari_{419,54,repo}, py{312,313}-PySide6-napari_{419,54,repo}
+envlist = py{39,310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-all, py{310,311,312,313}-{PyQt5,PyQt6}-napari_{419,54,repo},py39-{PyQt5,PyQt6}-napari_{419,54} , py{312,313}-PySide6-napari_{419,54,repo}
 toxworkdir=/tmp/tox
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ deps =
     napari_419: napari==0.4.19.post1
     napari_54: napari==0.5.4
 commands =
-    python -m pytest -v package/tests/test_PartSeg/test_napari_widgets.py --json-report --json-report-file={toxinidir}/report-{envname}-{sys_platform}.json {posargs}
+    python -m pytest -v  --json-report --json-report-file={toxinidir}/report-{envname}-{sys_platform}.json {posargs:package/tests/test_PartSeg/test_napari_widgets.py}
 
 
 [testenv:py{310,311,312,313}-{PyQt5,PyQt6,PySide6}-napari_repo]
@@ -86,7 +86,7 @@ deps =
     {[testenv]deps}
     git+https://github.com/napari/napari.git
 commands =
-    python -m pytest package/tests --json-report --json-report-file={toxinidir}/report-{envname}-{sys_platform}.json {posargs}
+    python -m pytest --json-report --json-report-file={toxinidir}/report-{envname}-{sys_platform}.json {posargs:package/tests}
 
 
 [testenv:py{39,310,311,312,313}-PyQt5-coverage]


### PR DESCRIPTION
Add testing napari repo against python 3.13

## Summary by Sourcery

Update napari testing configuration to separate repo-based tests from pinned napari versions and expand CI coverage to Python 3.13.

Enhancements:
- Split tox environments so napari widget tests run only against pinned napari versions while full test suite runs against the napari repo for selected Qt backends.
- Stop running napari repo tests with the PySide2 backend in favor of PyQt5, PyQt6, and PySide6.

CI:
- Extend the napari repo GitHub Actions workflow matrix to include Python 3.13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI to include Python 3.13 and reorganized test environments to separate repo-based runs for clearer, targeted testing and headless-display setup.
* **Bug Fixes**
  * Viewer windows are now initialized hidden and only shown after setup completes to prevent premature rendering.
* **Tests**
  * Updated tests to instantiate viewers without immediate rendering and adjusted test invocations to align with the new CI/testenv layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->