### PR TITLE
chore: Update coderabbitai configuration to not expect docstrings in test

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,3 +3,7 @@ reviews:
     github-checks:
       enabled: true
       timeout_ms: 900000  # 15 minutes (maximum allowed)
+
+  path_instructions:
+    - path: "package/tests/**/*.py"
+      instructions: "Docstrings are not required for test functions in test files."


### PR DESCRIPTION
https://github.com/4DNucleome/PartSeg/pull/1352#issuecomment-3887569254

## Summary by Sourcery

Build:
- Update CodeRabbit configuration to exempt Python test files from requiring docstrings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to clarify that docstrings are not required for test functions in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->