### PR TITLE
chore: Move czifile fix to a separate file

### DIFF
--- a/package/PartSegImage/__init__.py
+++ b/package/PartSegImage/__init__.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from PartSegImage import tifffile_fixes  # noqa: F401
+from PartSegImage import czifile_fixes  # noqa: F401
 from PartSegImage.channel_class import Channel
 from PartSegImage.image import ChannelInfo, ChannelInfoFull, Image
 from PartSegImage.image_reader import (

--- a/package/PartSegImage/__init__.py
+++ b/package/PartSegImage/__init__.py
@@ -1,8 +1,10 @@
 import os
 import sys
 
-from PartSegImage import tifffile_fixes  # noqa: F401
-from PartSegImage import czifile_fixes  # noqa: F401
+from PartSegImage import (
+    czifile_fixes,  # noqa: F401
+    tifffile_fixes,  # noqa: F401
+)
 from PartSegImage.channel_class import Channel
 from PartSegImage.image import ChannelInfo, ChannelInfoFull, Image
 from PartSegImage.image_reader import (

--- a/package/PartSegImage/czifile_fixes.py
+++ b/package/PartSegImage/czifile_fixes.py
@@ -7,7 +7,7 @@ from packaging.version import parse as parse_version
 
 if parse_version(metadata.version("czifile")) < parse_version("2026.3.12"):
     import imagecodecs
-    from czifile import DECOMPRESS
+    from czifile.czifile import DECOMPRESS
 
     class ZSTD1Header(typing.NamedTuple):
         """

--- a/package/PartSegImage/czifile_fixes.py
+++ b/package/PartSegImage/czifile_fixes.py
@@ -1,0 +1,76 @@
+import inspect
+import typing
+
+from importlib import metadata
+from packaging.version import parse as parse_version
+import numpy as np
+
+
+if parse_version(metadata.version("czifile")) < parse_version("2026.3.12"):
+    from czifile import DECOMPRESS
+    import imagecodecs
+
+
+    class ZSTD1Header(typing.NamedTuple):
+        """
+        ZSTD1 header structure
+        based on:
+        https://github.com/ZEISS/libczi/blob/4a60e22200cbf0c8ff2a59f69a81ef1b2b89bf4f/Src/libCZI/decoder_zstd.cpp#L19
+        """
+
+        header_size: int
+        hiLoByteUnpackPreprocessing: bool
+
+
+    def parse_zstd1_header(data: bytes, size: int) -> ZSTD1Header:  # pragma: no cover
+        """
+        Parse ZSTD header
+
+        https://github.com/ZEISS/libczi/blob/4a60e22200cbf0c8ff2a59f69a81ef1b2b89bf4f/Src/libCZI/decoder_zstd.cpp#L84
+        """
+        if size < 1:
+            return ZSTD1Header(0, False)
+
+        if data[0] == 1:
+            return ZSTD1Header(1, False)
+
+        if data[0] == 3 and size < 3:
+            return ZSTD1Header(0, False)
+
+        if data[1] == 1:
+            return ZSTD1Header(3, bool(data[2] & 1))
+
+        return ZSTD1Header(0, False)
+
+
+    def _get_dtype():
+        return inspect.currentframe().f_back.f_back.f_locals["de"].dtype
+
+
+    def decode_zstd1(data: bytes) -> np.ndarray:
+        """
+        Decode ZSTD1 data
+        """
+        header = parse_zstd1_header(data, len(data))
+        dtype = _get_dtype()
+        if header.hiLoByteUnpackPreprocessing:
+            array_ = np.frombuffer(imagecodecs.zstd_decode(data[header.header_size:]), np.uint8).copy()
+            half_size = array_.size // 2
+            array = np.empty(half_size, np.uint16)
+            array[:] = array_[:half_size] + (array_[half_size:].astype(np.uint16) << 8)
+            array = array.view(dtype)
+        else:
+            array = np.frombuffer(imagecodecs.zstd_decode(data[header.header_size:]), dtype).copy()
+        return array
+
+
+    def decode_zstd0(data: bytes) -> np.ndarray:
+        """
+        Decode ZSTD0 data
+        """
+        dtype = _get_dtype()
+        return np.frombuffer(imagecodecs.zstd_decode(data), dtype).copy()
+
+
+    DECOMPRESS[5] = decode_zstd0
+    DECOMPRESS[6] = decode_zstd1

--- a/package/PartSegImage/czifile_fixes.py
+++ b/package/PartSegImage/czifile_fixes.py
@@ -1,15 +1,13 @@
 import inspect
 import typing
-
 from importlib import metadata
-from packaging.version import parse as parse_version
-import numpy as np
 
+import numpy as np
+from packaging.version import parse as parse_version
 
 if parse_version(metadata.version("czifile")) < parse_version("2026.3.12"):
-    from czifile import DECOMPRESS
     import imagecodecs
-
+    from czifile import DECOMPRESS
 
     class ZSTD1Header(typing.NamedTuple):
         """
@@ -20,7 +18,6 @@ if parse_version(metadata.version("czifile")) < parse_version("2026.3.12"):
 
         header_size: int
         hiLoByteUnpackPreprocessing: bool
-
 
     def parse_zstd1_header(data: bytes, size: int) -> ZSTD1Header:  # pragma: no cover
         """
@@ -42,10 +39,8 @@ if parse_version(metadata.version("czifile")) < parse_version("2026.3.12"):
 
         return ZSTD1Header(0, False)
 
-
     def _get_dtype():
         return inspect.currentframe().f_back.f_back.f_locals["de"].dtype
-
 
     def decode_zstd1(data: bytes) -> np.ndarray:
         """
@@ -54,15 +49,14 @@ if parse_version(metadata.version("czifile")) < parse_version("2026.3.12"):
         header = parse_zstd1_header(data, len(data))
         dtype = _get_dtype()
         if header.hiLoByteUnpackPreprocessing:
-            array_ = np.frombuffer(imagecodecs.zstd_decode(data[header.header_size:]), np.uint8).copy()
+            array_ = np.frombuffer(imagecodecs.zstd_decode(data[header.header_size :]), np.uint8).copy()
             half_size = array_.size // 2
             array = np.empty(half_size, np.uint16)
             array[:] = array_[:half_size] + (array_[half_size:].astype(np.uint16) << 8)
             array = array.view(dtype)
         else:
-            array = np.frombuffer(imagecodecs.zstd_decode(data[header.header_size:]), dtype).copy()
+            array = np.frombuffer(imagecodecs.zstd_decode(data[header.header_size :]), dtype).copy()
         return array
-
 
     def decode_zstd0(data: bytes) -> np.ndarray:
         """
@@ -70,7 +64,6 @@ if parse_version(metadata.version("czifile")) < parse_version("2026.3.12"):
         """
         dtype = _get_dtype()
         return np.frombuffer(imagecodecs.zstd_decode(data), dtype).copy()
-
 
     DECOMPRESS[5] = decode_zstd0
     DECOMPRESS[6] = decode_zstd1

--- a/package/PartSegImage/image_reader.py
+++ b/package/PartSegImage/image_reader.py
@@ -2,6 +2,7 @@ import os.path
 import typing
 from abc import abstractmethod
 from contextlib import suppress
+from importlib import metadata
 from io import BytesIO
 from itertools import zip_longest
 from pathlib import Path
@@ -12,9 +13,7 @@ import tifffile
 from czifile import CziFile
 from defusedxml import ElementTree
 from oiffile import OifFile
-
 from packaging.version import parse as parse_version
-from importlib import metadata
 
 CZIFILE_ABOVE_2026_3_12 = parse_version(metadata.version("czifile")) >= parse_version("2026.3.12")
 

--- a/package/PartSegImage/image_reader.py
+++ b/package/PartSegImage/image_reader.py
@@ -15,9 +15,9 @@ from defusedxml import ElementTree
 from oiffile import OifFile
 from packaging.version import parse as parse_version
 
-CZIFILE_ABOVE_2026_3_12 = parse_version(metadata.version("czifile")) >= parse_version("2026.3.12")
-
 from PartSegImage.image import ChannelInfo, Image
+
+CZIFILE_ABOVE_2026_3_12 = parse_version(metadata.version("czifile")) >= parse_version("2026.3.12")
 
 INCOMPATIBLE_IMAGE_MASK = "Incompatible shape of mask and image"
 

--- a/package/PartSegImage/image_reader.py
+++ b/package/PartSegImage/image_reader.py
@@ -9,9 +9,14 @@ from threading import Lock
 
 import numpy as np
 import tifffile
-from czifile.czifile import CziFile
+from czifile import CziFile
 from defusedxml import ElementTree
 from oiffile import OifFile
+
+from packaging.version import parse as parse_version
+from importlib import metadata
+
+CZIFILE_ABOVE_2026_3_12 = parse_version(metadata.version("czifile")) >= parse_version("2026.3.12")
 
 from PartSegImage.image import ChannelInfo, Image
 
@@ -291,9 +296,17 @@ class CziImageReader(BaseImageReaderBuffer):
 
     def read(self, image_path: typing.Union[str, BytesIO, Path], mask_path=None, ext=None) -> Image:
         image_file = CziFile(image_path)
-        image_data = image_file.asarray(max_workers=CZI_MAX_WORKERS)
-        image_data = self.update_array_shape(image_data, image_file.axes)
-        metadata = image_file.metadata(False)
+
+        if CZIFILE_ABOVE_2026_3_12:
+            image_data = image_file.asarray(maxworkers=CZI_MAX_WORKERS)
+            axes = image_file.scenes[0].axes
+            metadata = image_file.metadata(asdict=True)
+        else:
+            image_data = image_file.asarray(max_workers=CZI_MAX_WORKERS)
+            axes = image_file.axes
+            metadata = image_file.metadata(False)
+        image_data = self.update_array_shape(image_data, axes)
+
         with suppress(KeyError):
             scaling = metadata["ImageDocument"]["Metadata"]["Scaling"]["Items"]["Distance"]
             scale_info = {el["Id"]: el["Value"] for el in scaling}

--- a/package/PartSegImage/image_reader.py
+++ b/package/PartSegImage/image_reader.py
@@ -1,21 +1,17 @@
-import inspect
 import os.path
 import typing
 from abc import abstractmethod
 from contextlib import suppress
-from importlib.metadata import version
 from io import BytesIO
 from itertools import zip_longest
 from pathlib import Path
 from threading import Lock
 
-import imagecodecs
 import numpy as np
 import tifffile
-from czifile.czifile import DECOMPRESS, CziFile
+from czifile.czifile import CziFile
 from defusedxml import ElementTree
 from oiffile import OifFile
-from packaging.version import parse as parse_version
 
 from PartSegImage.image import ChannelInfo, Image
 
@@ -27,72 +23,6 @@ if typing.TYPE_CHECKING:
 
 
 CZI_MAX_WORKERS = None
-
-
-class ZSTD1Header(typing.NamedTuple):
-    """
-    ZSTD1 header structure
-    based on:
-    https://github.com/ZEISS/libczi/blob/4a60e22200cbf0c8ff2a59f69a81ef1b2b89bf4f/Src/libCZI/decoder_zstd.cpp#L19
-    """
-
-    header_size: int
-    hiLoByteUnpackPreprocessing: bool
-
-
-def parse_zstd1_header(data: bytes, size: int) -> ZSTD1Header:  # pragma: no cover
-    """
-    Parse ZSTD header
-
-    https://github.com/ZEISS/libczi/blob/4a60e22200cbf0c8ff2a59f69a81ef1b2b89bf4f/Src/libCZI/decoder_zstd.cpp#L84
-    """
-    if size < 1:
-        return ZSTD1Header(0, False)
-
-    if data[0] == 1:
-        return ZSTD1Header(1, False)
-
-    if data[0] == 3 and size < 3:
-        return ZSTD1Header(0, False)
-
-    if data[1] == 1:
-        return ZSTD1Header(3, bool(data[2] & 1))
-
-    return ZSTD1Header(0, False)
-
-
-def _get_dtype():
-    return inspect.currentframe().f_back.f_back.f_locals["de"].dtype
-
-
-def decode_zstd1(data: bytes) -> np.ndarray:
-    """
-    Decode ZSTD1 data
-    """
-    header = parse_zstd1_header(data, len(data))
-    dtype = _get_dtype()
-    if header.hiLoByteUnpackPreprocessing:
-        array_ = np.frombuffer(imagecodecs.zstd_decode(data[header.header_size :]), np.uint8).copy()
-        half_size = array_.size // 2
-        array = np.empty(half_size, np.uint16)
-        array[:] = array_[:half_size] + (array_[half_size:].astype(np.uint16) << 8)
-        array = array.view(dtype)
-    else:
-        array = np.frombuffer(imagecodecs.zstd_decode(data[header.header_size :]), dtype).copy()
-    return array
-
-
-def decode_zstd0(data: bytes) -> np.ndarray:
-    """
-    Decode ZSTD0 data
-    """
-    dtype = _get_dtype()
-    return np.frombuffer(imagecodecs.zstd_decode(data), dtype).copy()
-
-
-if parse_version(version("czifile")) in {parse_version("2019.7.2"), parse_version("2019.7.2.1")}:
-    DECOMPRESS[5] = decode_zstd0
-    DECOMPRESS[6] = decode_zstd1
 
 
 def _empty(_, __):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,8 @@ pyside = [
 ]
 pyside2 = [
     "PySide2!=5.15.0,>=5.12.3",
-    "napari[pyside]",
+    "napari[pyside]<0.7.0",
+    "superqt<0.8.0"
 ]
 pyside6 = [
     "PySide6",

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
     PySide6: PySide6<6.3.2; python_version < "3.10"
     PySide6: PySide6; python_version >= "3.10"
     PySide2: npe2!=0.2.2
+    PySide2: superqt<0.8.0
     imageio != 2.22.1
     pytest-json-report
 


### PR DESCRIPTION
As czifile v2026.3.12 implements zstd support and removed `DECOMPRESS` dict there is a need to move it to a separate file and hide under if-clause.

## Summary by Sourcery

Enhancements:
- Move legacy czifile zstd decompression handlers from the main image reader into a separate czifile_fixes module guarded by a version check to maintain compatibility with older czifile releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compatibility for reading CZI images using ZSTD compression on older image-library versions.

* **Refactor**
  * Decompression handling moved into a compatibility module; core image reader simplified and now uses a version-gated path for newer/older library behavior.
  * Module initialization updated to include the compatibility fixes.

* **Chores**
  * Tightened PySide/GUI dependency version constraints for more predictable installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->