### PR TITLE
chore: Fix overwriting default path for napari settings in tests

### DIFF
--- a/package/tests/test_PartSeg/conftest.py
+++ b/package/tests/test_PartSeg/conftest.py
@@ -1,7 +1,9 @@
 import contextlib
 from contextlib import suppress
+from importlib import metadata
 
 import pytest
+from packaging.version import parse as parse_version
 from qtpy.QtWidgets import QDialog, QInputDialog, QMessageBox
 
 from PartSeg._roi_analysis.partseg_settings import PartSettings
@@ -9,6 +11,8 @@ from PartSeg._roi_mask.main_window import ChosenComponents
 from PartSeg._roi_mask.stack_settings import StackSettings
 from PartSeg.common_backend.base_settings import BaseSettings
 from PartSeg.common_gui import napari_image_view
+
+NAPARI_GE_0_7_0 = parse_version(metadata.version("napari")) >= parse_version("0.7.0a0")
 
 
 @pytest.fixture
@@ -120,7 +124,10 @@ def _reset_napari_settings(monkeypatch, tmp_path):
 
     from napari import settings
 
-    cp = settings.NapariSettings.__private_attributes__["_config_path"]
+    if NAPARI_GE_0_7_0:
+        cp = settings.NapariSettings.model_fields["config_path"]
+    else:
+        cp = settings.NapariSettings.__private_attributes__["_config_path"]
     monkeypatch.setattr(cp, "default", tmp_path / "save.yaml")
     monkeypatch.setattr(settings.NapariSettings, "save", _mock_save)
     settings._SETTINGS = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ pyside = [
 pyside2 = [
     "PySide2!=5.15.0,>=5.12.3",
     "napari[pyside]<0.7.0",
-    "superqt<0.8.0"
 ]
 pyside6 = [
     "PySide6",


### PR DESCRIPTION
closes #1257
closes #1348
closes #1349

## Summary by Sourcery

Update test configuration and dependencies to handle changes in napari settings configuration path handling across versions.

Build:
- Relax PySide2 extra dependency constraints by dropping the superqt<0.8.0 pin.

Tests:
- Adjust napari settings path monkeypatching in tests to support napari versions before and after 0.7.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Napari versions 0.7.0 and newer through version-aware configuration handling to ensure proper functionality and stability across different napari releases
* **Chores**
  * Removed restrictive version constraint on the superqt dependency, allowing the installation and use of newer superqt versions with the napari pyside backend while maintaining full compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->