### PR TITLE
chore: Use `pyvista/setup-headless-display-action` for setup display

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -35,14 +35,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: tlambert03/setup-qt-libs@v1
-      - name: Install Windows OpenGL
-        if: runner.os == 'Windows'
-        run: |
-          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
-          powershell gl-ci-helpers/appveyor/install_opengl.ps1
-          if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
-        shell: powershell
+      - name: Setup headless display
+        uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2
+        with:
+          qt: true
+          wm: herbstluftwm
+
       - name: Install PartSeg
         run: python -m pip install --editable ".[pyinstaller]" --constraint requirements/constraints_py3.12.txt
 
@@ -56,9 +54,7 @@ jobs:
           path: dist2
 
       - name: Test PartSeg bundle
-        uses: aganders3/headless-gui@v2
-        with:
-          run: dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test
+        run: dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test || dist/PartSeg/PartSeg _test
 
 
   create_release:

--- a/.github/workflows/test_napari_repo.yml
+++ b/.github/workflows/test_napari_repo.yml
@@ -44,15 +44,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install Windows OpenGL
-        if: runner.os == 'Windows'
-        run: |
-          git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
-          powershell gl-ci-helpers/appveyor/install_opengl.ps1
-          if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
-        shell: powershell
-
-      - uses: tlambert03/setup-qt-libs@v1
+      - name: Setup headless display
+        uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2
+        with:
+          qt: true
+          wm: herbstluftwm
 
       - name: Install dependencies
         run: |
@@ -67,10 +63,8 @@ jobs:
 
       - name: Test with tox
         # run tests using pip install --pre
-        uses: aganders3/headless-gui@v2
         timeout-minutes: 60
-        with:
-          run: tox
+        run: tox
         env:
           PLATFORM: ${{ matrix.platform }}
           NAPARI: ${{ matrix.napari_version }}

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -62,10 +62,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'pyproject.toml'
 
-      - name: Install Windows OpenGL
-        uses: pyvista/setup-headless-display-action@v4
-
-      - uses: tlambert03/setup-qt-libs@v1
+      - name: Setup headless display
+        uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2
+        with:
+          qt: true
+          wm: herbstluftwm
 
       - name: Download test data
         uses: actions/download-artifact@v7
@@ -80,10 +81,8 @@ jobs:
 
       - name: Test with tox base
         # run tests using pip install --pre
-        uses: aganders3/headless-gui@v2
         timeout-minutes: 60
-        with:
-          run: python -m tox run -v -- -v package/tests/test_PartSegImage package/tests/test_PartSegCore
+        run: python -m tox run -v -- -v package/tests/test_PartSegImage package/tests/test_PartSegCore
         env:
           PLATFORM: ${{ matrix.platform }}
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
@@ -94,10 +93,8 @@ jobs:
 
       - name: Test with tox linux
         # run tests using pip install --pre
-        uses: aganders3/headless-gui@v2
         timeout-minutes: 60
-        with:
-          run: python -m tox run -v -- -v package/tests/test_PartSeg
+        run: python -m tox run -v -- -v package/tests/test_PartSeg
         env:
           PLATFORM: ${{ matrix.platform }}
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
@@ -125,19 +122,21 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
-      name: Install Python
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v7
       with:
-        python-version: 3.x
-    - uses: tlambert03/setup-qt-libs@v1
-    - name: Install uv
-      run: pip install uv
+        activate-environment: 'true'
+        python-version: '3.12'
+    - name: Setup headless display
+      uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2
+      with:
+        qt: true
+        wm: herbstluftwm
     - name: Compile PyInstaller requirements
       run: |
         uv pip compile --prerelease allow --python-version 3.12 --upgrade -o requirements.txt pyproject.toml requirements/pre_test_problematic_version.txt --extra pyinstaller
     - name: Install dependencies
       run: |
-        uv venv --python 3.12
         uv pip install -r requirements.txt
         uv pip install .
     - name: upload requirements
@@ -147,7 +146,6 @@ jobs:
         path: requirements.txt
     - name: Run PyInstaller
       run: |
-        source .venv/bin/activate
         python build_utils/create_and_pack_executable.py
     - name: Upload bundle
       uses: actions/upload-artifact@v7
@@ -155,10 +153,8 @@ jobs:
         name: bundle
         path: dist2/
     - name: Test bundle
-      uses: aganders3/headless-gui@v2
       timeout-minutes: 60
-      with:
-        run: dist/PartSeg/PartSeg _test
+      run: dist/PartSeg/PartSeg _test
 
       # If something goes wrong, we can open an issue in the repo
     - name: Report Failures


### PR DESCRIPTION
use `astral-sh/setup-uv` to setup uv instead of manual setup uv

## Summary by Sourcery

Update CI workflows to use a unified headless display setup and streamline Python/uv environment management for testing and releases.

CI:
- Replace platform-specific OpenGL and Qt setup with pyvista/setup-headless-display-action configured for Qt and herbstluftwm across test and release workflows.
- Simplify test and bundle execution steps by running commands directly in the job steps instead of via aganders3/headless-gui.
- Switch prerelease testing workflow to install and activate uv using astral-sh/setup-uv with Python 3.12 instead of manually creating and activating a virtual environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to streamline display and environment setup processes across multiple testing and build pipelines.

---

**Note:** This release contains infrastructure and tooling improvements with no user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->