### PR TITLE
chore: Replace `appdirs`package with `platformdirs`

### DIFF
--- a/package/PartSeg/state_store.py
+++ b/package/PartSeg/state_store.py
@@ -5,8 +5,8 @@ Module with default values of application state
 import os
 import sys
 
-import appdirs
 import packaging.version
+import platformdirs
 
 from PartSeg import APP_LAB, APP_NAME, __version__, parsed_version
 
@@ -28,7 +28,7 @@ develop = False
 save_suffix = ""
 #: path to folder where save settings
 save_folder = os.path.join(
-    os.environ.get("PARTSEG_SETTINGS_DIR", appdirs.user_data_dir(APP_NAME, APP_LAB)),
+    os.environ.get("PARTSEG_SETTINGS_DIR", platformdirs.user_data_dir(APP_NAME, APP_LAB)),
     str(packaging.version.parse(__version__).base_version),
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Framework :: napari",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3"
+    ,
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -45,7 +46,7 @@ dependencies = [
     "QtAwesome!=1.2.0,>=1.0.3",
     "QtPy>=1.10.0",
     "SimpleITK>=2.1.0",
-    "appdirs>=1.4.4",
+    "platformdirs>=4.3.0",
     "czifile>=2019.5.22",
     "defusedxml>=0.6.0",
     "fonticon-fontawesome6>=6.1.1",

--- a/requirements/constraints_py3.10.txt
+++ b/requirements/constraints_py3.10.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.4.0
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.10.txt
+++ b/requirements/constraints_py3.10.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.4.0
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.10_pydantic_1.txt
+++ b/requirements/constraints_py3.10_pydantic_1.txt
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via typer
 app-model==0.3.2
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.10_pydantic_1.txt
+++ b/requirements/constraints_py3.10_pydantic_1.txt
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via typer
 app-model==0.3.2
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.11.txt
+++ b/requirements/constraints_py3.11.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.4.0
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.11.txt
+++ b/requirements/constraints_py3.11.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.4.0
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.11_pydantic_1.txt
+++ b/requirements/constraints_py3.11_pydantic_1.txt
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via typer
 app-model==0.3.2
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.11_pydantic_1.txt
+++ b/requirements/constraints_py3.11_pydantic_1.txt
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via typer
 app-model==0.3.2
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.12.txt
+++ b/requirements/constraints_py3.12.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.4.0
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.12.txt
+++ b/requirements/constraints_py3.12.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.4.0
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.12_docs.txt
+++ b/requirements/constraints_py3.12_docs.txt
@@ -8,7 +8,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.4.0
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.12_docs.txt
+++ b/requirements/constraints_py3.12_docs.txt
@@ -8,7 +8,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.4.0
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.12_pydantic_1.txt
+++ b/requirements/constraints_py3.12_pydantic_1.txt
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via typer
 app-model==0.3.2
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.12_pydantic_1.txt
+++ b/requirements/constraints_py3.12_pydantic_1.txt
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via typer
 app-model==0.3.2
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.13.txt
+++ b/requirements/constraints_py3.13.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.4.0
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.13.txt
+++ b/requirements/constraints_py3.13.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.4.0
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.13_pydantic_1.txt
+++ b/requirements/constraints_py3.13_pydantic_1.txt
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via typer
 app-model==0.3.2
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.13_pydantic_1.txt
+++ b/requirements/constraints_py3.13_pydantic_1.txt
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via typer
 app-model==0.3.2
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.9.txt
+++ b/requirements/constraints_py3.9.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.3.2
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.9.txt
+++ b/requirements/constraints_py3.9.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 app-model==0.3.2
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.9_pydantic_1.txt
+++ b/requirements/constraints_py3.9_pydantic_1.txt
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via typer
 app-model==0.3.2
     # via napari
-platformdirs==4.3.6
+
     # via
     #   partseg (pyproject.toml)
     #   napari

--- a/requirements/constraints_py3.9_pydantic_1.txt
+++ b/requirements/constraints_py3.9_pydantic_1.txt
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via typer
 app-model==0.3.2
     # via napari
-appdirs==1.4.4
+platformdirs==4.3.6
     # via
     #   partseg (pyproject.toml)
     #   napari


### PR DESCRIPTION
## Summary by Sourcery

Replace usage of the deprecated appdirs package with platformdirs across configuration and runtime settings handling.

Enhancements:
- Update settings directory resolution to use platformdirs instead of appdirs.

Build:
- Replace appdirs dependency with platformdirs in project configuration and constraints as needed.

Chores:
- Tidy pyproject metadata formatting in the classifiers list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched underlying platform directory provider used to determine the default settings/save folder; existing environment-variable override and versioned subfolder behavior remain unchanged.
  * Removed legacy pinned package and updated dependency metadata to reflect the new platform directory dependency across supported Python versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->