### PR TITLE
chore: Limit superqt version bellow 0.8.0 when install pyside2 as qt backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ pyside = [
 pyside2 = [
     "PySide2!=5.15.0,>=5.12.3",
     "napari[pyside]<0.7.0",
-    "superqt<0.8.0",
+    "superqt<0.8.0",  # superqt 0.8+ uses type annotations which are not supported in pyside2, so we need to use older version
 ]
 pyside6 = [
     "PySide6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ pyside = [
 pyside2 = [
     "PySide2!=5.15.0,>=5.12.3",
     "napari[pyside]<0.7.0",
+    "superqt<0.8.0",
 ]
 pyside6 = [
     "PySide6",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened optional dependency constraints for the PySide2 extras by adding an upper bound on the SuperQt package to improve compatibility and prevent incompatible versions.
  * No other dependency groups or core requirements were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->