### PR TITLE
chore: Use ubuntu-slim for check title workflow

### DIFF
--- a/.github/project_dict.pws
+++ b/.github/project_dict.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 29
+personal_ws-1.1 en 30
 napari
 autoupdate
 aspell
@@ -28,3 +28,4 @@ otsu
 ome
 ImageJ
 QtViewer
+ubuntu

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -34,7 +34,7 @@ jobs:
 
 
       - name: Install aspell
-        run: sudo apt-get install aspell
+        run: sudo apt-get update && sudo apt-get install aspell
 
       - name: Check PR title spelling
         env:

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   spellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip check PR title') }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the check_pr_title workflow to use the ubuntu-slim GitHub Actions runner instead of ubuntu-latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for automated quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->