### PR TITLE
chore: Prepare for numpy 2.5.0 by fix `find_density_orientation` implementation

### DIFF
--- a/.github/project_dict.pws
+++ b/.github/project_dict.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 30
+personal_ws-1.1 en 31
 napari
 autoupdate
 aspell
@@ -29,3 +29,4 @@ ome
 ImageJ
 QtViewer
 ubuntu
+numpy

--- a/package/PartSegCore/autofit.py
+++ b/package/PartSegCore/autofit.py
@@ -35,7 +35,7 @@ def find_density_orientation(img, voxel_size, cutoff=1):
     sorted_values = sorted(((values[i], vectors[:, i]) for i in range(3)), key=lambda y: y[0], reverse=True)
     values = [x[0] for x in sorted_values]
     vectors = np.array([x[1] for x in sorted_values]).T
-    if np.any(vectors.imag):
+    if np.any(vectors.imag):  # pragma: no cover
         raise ValueError("Complex eigenvectors found, which should not happen for real symmetric matrices")
     w_n = values / np.sum(values) * 1000  # Drawing coordinates
     return vectors.real, w_n

--- a/package/PartSegCore/autofit.py
+++ b/package/PartSegCore/autofit.py
@@ -24,22 +24,22 @@ def find_density_orientation(img, voxel_size, cutoff=1):
     points_l[:, 1] *= voxel_size[-2]
     points_l[:, 2] *= voxel_size[-1]
     points = points_l.astype(np.float64)
-    punkty_wazone = np.empty(points.shape)
+    weighted_points = np.empty(points.shape)
     for i in range(3):
-        punkty_wazone[:, i] = points[:, i] * weights
-    mean = np.sum(punkty_wazone, axis=0) / np.sum(weights)
+        weighted_points[:, i] = points[:, i] * weights
+    mean = np.sum(weighted_points, axis=0) / np.sum(weights)
     points_shifted = points - mean
-    wheighted_points_shifted = np.copy(points_shifted)
+    weighted_points_shifted = np.copy(points_shifted)
     for i in range(3):
-        wheighted_points_shifted[:, i] *= weights
-    cov = np.dot(wheighted_points_shifted.transpose(), points_shifted) * 1 / (len(weights) - 1)
+        weighted_points_shifted[:, i] *= weights
+    cov = np.dot(weighted_points_shifted.transpose(), points_shifted) * 1 / (len(weights) - 1)
     # cov variable is weighted covariance matrix
     values, vectors = np.linalg.eig(cov)
     sorted_values = sorted(((values[i], vectors[:, i]) for i in range(3)), key=lambda y: y[0], reverse=True)
     values = [x[0] for x in sorted_values]
     vectors = np.array([x[1] for x in sorted_values]).T
     w_n = values / np.sum(values) * 1000  # Drawing coordinates
-    return vectors, w_n
+    return vectors.real, w_n
 
 
 def get_rotation_parameters(isometric_matrix):  # pragma: no cover

--- a/package/PartSegCore/autofit.py
+++ b/package/PartSegCore/autofit.py
@@ -36,7 +36,10 @@ def find_density_orientation(img, voxel_size, cutoff=1):
     values = [x[0] for x in sorted_values]
     vectors = np.array([x[1] for x in sorted_values]).T
     if np.any(vectors.imag):  # pragma: no cover
-        raise ValueError("Complex eigenvectors found, which should not happen for real symmetric matrices")
+        raise ValueError(
+            "Complex eigenvectors found, which should not happen for "
+            f"real symmetric matrices. Abs {np.max(np.abs(vectors.imag))}"
+        )
     w_n = values / np.sum(values) * 1000  # Drawing coordinates
     return vectors.real, w_n
 

--- a/package/PartSegCore/autofit.py
+++ b/package/PartSegCore/autofit.py
@@ -24,20 +24,19 @@ def find_density_orientation(img, voxel_size, cutoff=1):
     points_l[:, 1] *= voxel_size[-2]
     points_l[:, 2] *= voxel_size[-1]
     points = points_l.astype(np.float64)
-    weighted_points = np.empty(points.shape)
-    for i in range(3):
-        weighted_points[:, i] = points[:, i] * weights
+    weighted_points = points * weights[:, None]
     mean = np.sum(weighted_points, axis=0) / np.sum(weights)
     points_shifted = points - mean
-    weighted_points_shifted = np.copy(points_shifted)
-    for i in range(3):
-        weighted_points_shifted[:, i] *= weights
+    weighted_points_shifted = points_shifted * weights[:, None]
+
     cov = np.dot(weighted_points_shifted.transpose(), points_shifted) * 1 / (len(weights) - 1)
     # cov variable is weighted covariance matrix
     values, vectors = np.linalg.eig(cov)
     sorted_values = sorted(((values[i], vectors[:, i]) for i in range(3)), key=lambda y: y[0], reverse=True)
     values = [x[0] for x in sorted_values]
     vectors = np.array([x[1] for x in sorted_values]).T
+    if np.any(vectors.imag):
+        raise ValueError("Complex eigenvectors found, which should not happen for real symmetric matrices")
     w_n = values / np.sum(values) * 1000  # Drawing coordinates
     return vectors.real, w_n
 

--- a/package/PartSegCore/autofit.py
+++ b/package/PartSegCore/autofit.py
@@ -20,6 +20,8 @@ def find_density_orientation(
 
     points_l = np.nonzero(np.array(img > cutoff))
     weights = img[points_l]
+    if len(weights) < 2:  # pragma: no cover
+        raise ValueError("Not enough points to calculate orientation")
     points_l = np.transpose(points_l).astype(np.float64)
     if len(voxel_size) >= 3:
         points_l[:, 0] *= voxel_size[-3]

--- a/package/PartSegCore/autofit.py
+++ b/package/PartSegCore/autofit.py
@@ -4,7 +4,9 @@ from math import acos, pi, sqrt
 import numpy as np
 
 
-def find_density_orientation(img, voxel_size, cutoff=1):
+def find_density_orientation(
+    img, voxel_size, cutoff=1
+) -> tuple[np.ndarray[tuple[int, int], np.dtype[np.float64]], np.ndarray]:
     """
     Identify axis of point set.
 
@@ -31,17 +33,14 @@ def find_density_orientation(img, voxel_size, cutoff=1):
 
     cov = np.dot(weighted_points_shifted.transpose(), points_shifted) * 1 / (len(weights) - 1)
     # cov variable is weighted covariance matrix
-    values, vectors = np.linalg.eig(cov)
+    values: np.ndarray[tuple[int], np.dtype[np.float64]]
+    vectors: np.ndarray[tuple[int, int], np.dtype[np.float64]]
+    values, vectors = np.linalg.eigh(cov)
     sorted_values = sorted(((values[i], vectors[:, i]) for i in range(3)), key=lambda y: y[0], reverse=True)
-    values = [x[0] for x in sorted_values]
+    values = np.array([x[0] for x in sorted_values])
     vectors = np.array([x[1] for x in sorted_values]).T
-    if np.any(vectors.imag):  # pragma: no cover
-        raise ValueError(
-            "Complex eigenvectors found, which should not happen for "
-            f"real symmetric matrices. Abs {np.max(np.abs(vectors.imag))}"
-        )
     w_n = values / np.sum(values) * 1000  # Drawing coordinates
-    return vectors.real, w_n
+    return vectors, w_n
 
 
 def get_rotation_parameters(isometric_matrix):  # pragma: no cover

--- a/package/tests/test_PartSegCore/test_measurements.py
+++ b/package/tests/test_PartSegCore/test_measurements.py
@@ -1869,7 +1869,7 @@ class TestStatisticProfile:
                 area_array=segmentation[0] == 2, voxel_size=image.voxel_size, result_scalar=UNIT_SCALE[Units.nm.value]
             ),
         ]
-        assert result["LongestMainAxisLength"][0] == 55 * 50 * UNIT_SCALE[Units.nm.value]
+        assert np.isclose(result["LongestMainAxisLength"][0], 55 * 50 * UNIT_SCALE[Units.nm.value])
         assert np.isclose(result["LongestMainAxisLength per component"][0][0], 35 * 50 * UNIT_SCALE[Units.nm.value])
         assert np.isclose(result["LongestMainAxisLength per component"][0][1], 26 * 50 * UNIT_SCALE[Units.nm.value])
 


### PR DESCRIPTION
## Summary by Sourcery

closes #1393

Bug Fixes:
- Correct weighted point and covariance computation in find_density_orientation to use consistently named weighted arrays and return real-valued eigenvectors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected density-orientation calculations for consistent numeric results and added explicit detection/reporting of invalid (complex) orientations.

* **Refactor**
  * Optimized orientation computation for improved performance and more consistent results.

* **Chores**
  * Updated project dictionary word list (added "numpy").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->