### PR TITLE
chore: Remove `pyside2` form extras during constraints generation

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           set -x
           pip install -U uv
-          flags=(--extra pyqt6 --extra pyside2 --extra pyside6 --extra test --extra pyinstaller_base)
+          flags=(--extra pyqt6 --extra pyside6 --extra test --extra pyinstaller_base)
 
           for pyv in 3.10 3.11 3.12 3.13 3.14; do
             uv pip compile --python-version ${pyv} --upgrade --output-file requirements/constraints_py${pyv}.txt pyproject.toml requirements/version_denylist.txt "${flags[@]}"


### PR DESCRIPTION
The `pyside2`no longer have releases and is about to remove from project (as napari 0.7.0 changed bundle to `PySide6`)

## Summary by Sourcery

CI:
- Remove the pyside2 extra from the upgrade-dependencies workflow when compiling constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated dependency upgrade workflow configuration to use updated Python UI library options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->