### PR TITLE
chore: Change default Qt versions from 5 to 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ accelerate = [
 #    "PyOpenGL-accelerate>=3.1.5 ; platform_machine != 'arm64'",
 ]
 all = [
-    "PartSeg[accelerate,pyqt5]"
+    "PartSeg[accelerate,pyqt]"
 ]
 docs = [
     "autodoc-pydantic",
@@ -116,7 +116,7 @@ pyinstaller_base = [
     "pydantic",
 ]
 pyqt = [
-    "PartSeg[pyqt5]",
+    "PartSeg[pyqt6]",
 ]
 pyqt5 = [
     "PyQt5!=5.15.0,>=5.12.3",
@@ -127,7 +127,7 @@ pyqt6 = [
     "napari[pyqt6]>=0.5.0",
 ]
 pyside = [
-    "PartSeg[pyside2]",
+    "PartSeg[pyside6]",
 ]
 pyside2 = [
     "PySide2!=5.15.0,>=5.12.3",


### PR DESCRIPTION
Change default Qt binding to PyQt6. change `pyqt` extras to point PyQt6 instead of PyQt6. Change `pyside` extra to point `PySide6` instead of `PySide2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated optional Qt backend dependencies to newer versions
  * PyQt backend now targets PyQt6 instead of PyQt5
  * PySide backend now targets PySide6 instead of PySide2
  * Accelerate extra now includes PyQt6 backend support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->