### PR TITLE
chore: block using `mpmath==1.5.0a0` in pre test, as sympy is incompatybile with it

### DIFF
--- a/launcher.spec
+++ b/launcher.spec
@@ -97,7 +97,6 @@ hiddenimports = (
         "PartSegCore.napari_io",
         "tzdata",
         "scipy._external.array_api_compat.numpy.fft",
-        "mpmath.libmp",
     ]
     + [x.module_name for x in imageio_known_plugins.values()]
     + [x for x in collect_submodules("skimage") if "tests" not in x]

--- a/launcher.spec
+++ b/launcher.spec
@@ -97,6 +97,7 @@ hiddenimports = (
         "PartSegCore.napari_io",
         "tzdata",
         "scipy._external.array_api_compat.numpy.fft",
+        "mpmath.libmp",
     ]
     + [x.module_name for x in imageio_known_plugins.values()]
     + [x for x in collect_submodules("skimage") if "tests" not in x]

--- a/requirements/version_denylist.txt
+++ b/requirements/version_denylist.txt
@@ -5,3 +5,4 @@ PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2; python_version >= '3.10'
 npe2!=0.2.2
 imageio != 2.22.1
 pytest-qt!=4.5.0
+mpmath!=1.5.0a0


### PR DESCRIPTION
closes #1398

## Summary by Sourcery

Build:
- Include mpmath.libmp in the PyInstaller hidden imports list to restore successful launcher builds.