### PR TITLE
chore: Block `mpmath==1.5.0a0` for pre-tests

### DIFF
--- a/requirements/pre_test_problematic_version.txt
+++ b/requirements/pre_test_problematic_version.txt
@@ -2,3 +2,4 @@ mpmath!=1.4.0a0
 ipykernel!=7.0.0a0,!=7.0.0a1
 sentry-sdk!=3.0.0a1,!=3.0.0a2,!=3.0.0a3,!=3.0.0a4,!=3.0.0a5
 pydantic!=2.14.0a1
+mpmath!=1.5.0a0

--- a/requirements/version_denylist.txt
+++ b/requirements/version_denylist.txt
@@ -5,4 +5,3 @@ PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2; python_version >= '3.10'
 npe2!=0.2.2
 imageio != 2.22.1
 pytest-qt!=4.5.0
-mpmath!=1.5.0a0


### PR DESCRIPTION
closes #1422