### PR TITLE
chore: drop python 3.10 tests on napari repository

### DIFF
--- a/.github/workflows/test_napari_repo.yml
+++ b/.github/workflows/test_napari_repo.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ ubuntu-24.04 ]
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.11', '3.12', '3.13', '3.14']
         napari_version: ['repo']
     steps:
       - uses: actions/checkout@v6.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ commands =
     python -m pytest -v  --json-report --json-report-file={toxinidir}/report-{envname}-{sys_platform}.json {posargs:package/tests/test_PartSeg/test_napari_widgets.py}
 
 
-[testenv:py{310,311,312,313,314,315}-{PyQt5,PyQt6,PySide6}-napari_repo]
+[testenv:py{311,312,313,314,315}-{PyQt5,PyQt6,PySide6}-napari_repo]
 deps =
     {[testenv]deps}
     git+https://github.com/napari/napari.git


### PR DESCRIPTION
Napari dropped python 3.10 so we cannot test against it in napari_repo tests

## Summary by Sourcery

Update napari repository testing to align with supported Python versions by dropping 3.10 and adding 3.14.

CI:
- Adjust GitHub Actions napari_repo workflow matrix to stop testing against Python 3.10 and start testing against Python 3.14.

Tests:
- Update tox napari_repo test environments to remove Python 3.10 and include Python 3.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated automated test coverage to target Python 3.11–3.14.
  - Removed Python 3.10 from the supported test environment matrix.
  - Added Python 3.14 coverage across supported Qt configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->