### PR TITLE
fix: Fix scale bar migration for canvas change in napari 0.8.1

### DIFF
--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 _napari_ge_5 = parse_version(napari.__version__) >= parse_version("0.5.0a1")
 _napari_le_7_0 = parse_version(napari.__version__) <= parse_version("0.7.0")
+_napari_gt_8_0 = parse_version(napari.__version__) > parse_version("0.8.0")
 
 # if run with numpy<2 on macOS arm64 architecture compiled from pypi wheels
 # then it will crash with bus error if numpy is used in different thread
@@ -232,7 +233,10 @@ class ImageView(QWidget):
         self.settings.connect_to_profile("scale_bar_ticks", self._update_scale_bar_ticks)
 
     def _update_scale_bar_ticks(self):
-        self.viewer.scale_bar.ticks = self.settings.get_from_profile("scale_bar_ticks", True)
+        if _napari_gt_8_0:
+            self.viewer.canvas.overlays.scale_bar.ticks = self.settings.get_from_profile("scale_bar_ticks", True)
+        else:
+            self.viewer.scale_bar.ticks = self.settings.get_from_profile("scale_bar_ticks", True)
 
     def toggle_points_visibility(self):
         if self.points_layer is not None:
@@ -950,15 +954,11 @@ class NapariQtViewer(QtViewer):
         super().closeEvent(event)
 
     def _render(self):
-        if _napari_ge_5:
-            return self.canvas._scene_canvas.render()
-        return self.canvas.render()
+        return self.canvas._scene_canvas.render()
 
-    if _napari_ge_5:
-
-        @property
-        def view(self):
-            return self.canvas.view
+    @property
+    def view(self):
+        return self.canvas.view
 
 
 class SearchComponentModal(QtPopup):

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -233,10 +233,11 @@ class ImageView(QWidget):
         self.settings.connect_to_profile("scale_bar_ticks", self._update_scale_bar_ticks)
 
     def _update_scale_bar_ticks(self):
+        ticks = self.settings.get_from_profile("scale_bar_ticks", True)
         if _napari_gt_8_0:
-            self.viewer.canvas.overlays.scale_bar.ticks = self.settings.get_from_profile("scale_bar_ticks", True)
+            self.viewer.canvas.overlays.scale_bar.ticks = ticks
         else:
-            self.viewer.scale_bar.ticks = self.settings.get_from_profile("scale_bar_ticks", True)
+            self.viewer.scale_bar.ticks = ticks
 
     def toggle_points_visibility(self):
         if self.points_layer is not None:

--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     from vispy.scene import BaseCamera
 
 
-_napari_ge_5 = parse_version(napari.__version__) >= parse_version("0.5.0a1")
 _napari_le_7_0 = parse_version(napari.__version__) <= parse_version("0.7.0")
 _napari_gt_8_0 = parse_version(napari.__version__) > parse_version("0.8.0")
 


### PR DESCRIPTION
## Summary by Sourcery

Update napari image viewer integration to support API changes introduced in napari 0.8.1 while simplifying version-dependent rendering logic.

Bug Fixes:
- Fix scale bar tick configuration for napari versions above 0.8.0 by using the new canvas overlay API.

Enhancements:
- Simplify rendering and view access by removing legacy napari version branching and unifying on the scene canvas implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scale-bar tick configuration so tick display is consistent across supported Napari versions.
  * Fixed rendering and view wiring to behave consistently in newer Napari environments.
  * Reduced version-dependent differences in image display behavior for a more stable viewing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->