### PR TITLE
fix: Fix setting status of delete button in multiple files widget

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -24,3 +24,5 @@ coverage:
         paths: [ 'package/tests/.*' ]
 comment:
   require_changes: true  # if true: only post the PR comment if coverage changes
+github_checks:
+  annotations: true

--- a/package/PartSeg/common_gui/select_multiple_files.py
+++ b/package/PartSeg/common_gui/select_multiple_files.py
@@ -228,22 +228,21 @@ class AddFiles(QWidget):
             self.paths_input.setText(dial.selectedFiles()[0])
 
     def file_chosen(self):
-        self.delete_button.setEnabled(self.selected_files.currentRow() != -1)
+        self.delete_button.setEnabled(len(self.selected_files.selectedItems()) != 0)
 
     def delete_element(self):
-        item = self.selected_files.takeItem(self.selected_files.currentRow())
-        if item is None:
-            return
-        self.files_to_proceed.remove(item.file_path)
+        item: FileListItem
+        for item in self.selected_files.selectedItems():
+            self.files_to_proceed.remove(item.file_path)
         self.file_list_changed.emit(self.files_to_proceed)
         if self.selected_files.count() == 0:
-            self.delete_button.setDisabled(True)
+            self.delete_button.setEnabled(False)
 
     def clean(self):
         self.selected_files.clear()
         self.files_to_proceed.clear()
         self.file_list_changed.emit(self.files_to_proceed)
-        self.delete_button.setDisabled(True)
+        self.delete_button.setEnabled(False)
 
     def get_paths(self):
         return sorted(self.files_to_proceed)

--- a/package/PartSeg/common_gui/select_multiple_files.py
+++ b/package/PartSeg/common_gui/select_multiple_files.py
@@ -234,6 +234,7 @@ class AddFiles(QWidget):
         item: FileListItem
         for item in self.selected_files.selectedItems():
             self.files_to_proceed.remove(item.file_path)
+            self.selected_files.takeItem(self.selected_files.row(item))
         self.file_list_changed.emit(self.files_to_proceed)
         if self.selected_files.count() == 0:
             self.delete_button.setEnabled(False)

--- a/package/PartSeg/common_gui/select_multiple_files.py
+++ b/package/PartSeg/common_gui/select_multiple_files.py
@@ -228,10 +228,12 @@ class AddFiles(QWidget):
             self.paths_input.setText(dial.selectedFiles()[0])
 
     def file_chosen(self):
-        self.delete_button.setEnabled(True)
+        self.delete_button.setEnabled(self.selected_files.currentRow() != -1)
 
     def delete_element(self):
         item = self.selected_files.takeItem(self.selected_files.currentRow())
+        if item is None:
+            return
         self.files_to_proceed.remove(item.file_path)
         self.file_list_changed.emit(self.files_to_proceed)
         if self.selected_files.count() == 0:
@@ -241,6 +243,7 @@ class AddFiles(QWidget):
         self.selected_files.clear()
         self.files_to_proceed.clear()
         self.file_list_changed.emit(self.files_to_proceed)
+        self.delete_button.setDisabled(True)
 
     def get_paths(self):
         return sorted(self.files_to_proceed)

--- a/package/tests/test_PartSeg/test_common_gui.py
+++ b/package/tests/test_PartSeg/test_common_gui.py
@@ -288,6 +288,17 @@ class TestAddFiles:
         widget.delete_element()
         assert len(widget.files_to_proceed) == 9
 
+    def test_delete_element_disable_button(self, qtbot, tmp_path, part_settings):
+        widget = select_multiple_files.AddFiles(part_settings)
+        qtbot.addWidget(widget)
+        file_name = tmp_path / "test.txt"
+        file_name.write_text("test")
+        widget.update_files_list([str(file_name)])
+        widget.selected_files.setCurrentRow(0)
+        assert widget.delete_button.isEnabled()
+        widget.delete_element()
+        assert widget.delete_button.isEnabled() is False
+
     def test_load_file(self, qtbot, tmp_path, part_settings):
         for i in range(10):
             with open(tmp_path / f"test_{i}.txt", "w") as f_p:


### PR DESCRIPTION
fix PARTSEG-10D

## Summary by Sourcery

Ensure the multiple-file widget keeps its delete action state synchronized with the current selection and file list.

Bug Fixes:
- Correct the multiple-file widget’s delete button state when files are selected, removed, or cleared.
- Support deleting all currently selected files from the multiple-file widget.

CI:
- Enable GitHub Checks annotations in Codecov reporting.

Tests:
- Add coverage verifying that deleting the final file disables the delete button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated multiple-file deletion to remove all selected files at once.
  * Improved the delete control state based on the current selection and remaining files.
  * Prevented deletion when no files remain or the selection is cleared.
  * Ensured deleting the only selected file correctly disables the delete control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->