### PR TITLE
fix: Re-add nme to pyinstaller bundle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ pyinstaller_base = [
     "PartSeg[accelerate]",
     "PyInstaller",
     "pydantic",
+    "nme", # for older plugins that still use nme
 ]
 pyqt = [
     "PartSeg[pyqt6]",


### PR DESCRIPTION
Some plugins still uses nme in place of local-migrator

fix PARTSEG-10B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated optional dependencies to enhance compatibility with older plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->