### PR TITLE
fix: Second fix for napari repository tests

### DIFF
--- a/package/PartSeg/common_gui/napari_image_view.py
+++ b/package/PartSeg/common_gui/napari_image_view.py
@@ -245,7 +245,10 @@ class ImageView(QWidget):
     def toggle_scale_bar(self):
         if _napari_le_7_0:
             self.viewer.scale_bar.unit = "nm"
-        self.viewer.scale_bar.visible = not self.viewer.scale_bar.visible
+        if _napari_gt_8_0:
+            self.viewer.canvas.overlays.scale_bar.visible = not self.viewer.canvas.overlays.scale_bar.visible
+        else:
+            self.viewer.scale_bar.visible = not self.viewer.scale_bar.visible
 
     def _dim_order_menu(self, point: QPoint):
         menu = QMenu()

--- a/package/tests/test_PartSeg/test_channel_control.py
+++ b/package/tests/test_PartSeg/test_channel_control.py
@@ -1,10 +1,12 @@
 # pylint: disable=no-self-use
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 from napari.utils.colormaps import make_colorbar
+from pytestqt.qtbot import QtBot
 from qtpy.QtCore import QPoint, Qt
 from qtpy.QtGui import QImage
 
@@ -294,11 +296,20 @@ class TestColorComboBoxGroup:
 
     @pytest.mark.windows_ci_skip
     @pytest.mark.parametrize("filter_value", NoiseFilterType.__members__.values())
-    def test_image_view_integration_filter(self, qtbot, tmp_path, filter_value, ch_property, image_view):
+    def test_image_view_integration_filter(
+        self,
+        qtbot: QtBot,
+        tmp_path: Path,
+        filter_value: NoiseFilterType,
+        ch_property: ChannelProperty,
+        image_view: ImageView,
+    ):
         image_view.channel_control.set_active(1)
 
-        def check_parameters(name, index):
+        def check_parameters(name: str, index: int):
             return name == "test" and index == 1
+
+        image_view.show()
 
         if filter_value is NoiseFilterType.No:
             with (
@@ -315,6 +326,7 @@ class TestColorComboBoxGroup:
         assert (filter_value != NoiseFilterType.No and np.any(image4 != 255)) or (
             filter_value == NoiseFilterType.No and np.any(image4 == 255)
         )
+        image_view.hide()
 
     @pytest.mark.windows_ci_skip
     def test_image_view_integration(self, qtbot, tmp_path, ch_property, image_view):


### PR DESCRIPTION
closes #1438

## Summary by Sourcery

Adjust napari image view behavior and related tests for compatibility with newer napari versions and stable test execution.

Enhancements:
- Make scale bar visibility toggling compatible with both older and newer napari versions by switching between viewer.scale_bar and viewer.canvas.overlays.scale_bar as needed.

Tests:
- Update napari image view integration tests to use typed qtbot/tmp_path parameters and explicitly show/hide the image view during filter tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scale bar compatibility across supported napari versions.
  * Preserved nanometer unit handling for older napari releases.
* **Tests**
  * Improved image-view integration test reliability by explicitly managing display visibility and strengthening test validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->