### PR TITLE
fix: Fix the colormap creation for Qt6

### DIFF
--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -43,6 +43,8 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
   COLUMNS: 120

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
     with:
       test_data: True
       python_version: "3.12"
-      tox_args: "-e py312-{qt_backend}-coverage"
+      tox_args: "-e py312-${{ matrix.qt_backend }}-coverage"
       coverage: true
 
   test_minimal:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.11", "3.12", "3.13", "3.14"]
+        python_version: ["3.11", "3.13", "3.14"]
         os: ["ubuntu-24.04"]
         qt_backend: ["PyQt6"]
         tox_args: [ "" ]
@@ -112,6 +112,8 @@ jobs:
             qt_backend: "PySide2"
           - os: "macos-15"
             qt_backend: "PySide2"
+          - python_version: "3.12"
+            qt_backend: "PyQt6"
     with:
       test_data: True
       python_version: ${{ matrix.python_version }}
@@ -123,10 +125,14 @@ jobs:
   test_coverage:
     needs: download_data
     uses: ./.github/workflows/base_test_workflow.yml
+    strategy:
+        fail-fast: false
+        matrix:
+          qt_backend: ["PyQt5", "PyQt6"]
     with:
       test_data: True
       python_version: "3.12"
-      tox_args: "-e py312-PyQt5-coverage"
+      tox_args: "-e py312-{qt_backend}-coverage"
       coverage: true
 
   test_minimal:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,7 @@ jobs:
       python_version: "3.12"
       tox_args: "-e py312-${{ matrix.qt_backend }}-coverage"
       coverage: true
+      qt_backend: ${{ matrix.qt_backend }}
 
   test_minimal:
     name: Test PartSeg minimal

--- a/package/PartSeg/common_gui/__init__.py
+++ b/package/PartSeg/common_gui/__init__.py
@@ -1,3 +1,3 @@
 """
-THis module contains Qt based widgets which are used in all PartSeg subprograms
+This module contains Qt-based widgets which are used in all PartSeg subprograms
 """

--- a/package/PartSeg/common_gui/qt_util.py
+++ b/package/PartSeg/common_gui/qt_util.py
@@ -19,4 +19,4 @@ else:
         return event.position().x()
 
     def get_mouse_y(event: QMouseEvent) -> float:
-        return event.position().x()
+        return event.position().y()

--- a/package/tests/test_PartSeg/test_common_gui.py
+++ b/package/tests/test_PartSeg/test_common_gui.py
@@ -20,8 +20,8 @@ from magicgui import register_type
 from magicgui.widgets import Container, Widget, create_widget
 from napari.utils import Colormap
 from pydantic import Field
-from qtpy.QtCore import QPoint, QRect, QSize, Qt
-from qtpy.QtGui import QPaintEvent
+from qtpy.QtCore import QEvent, QPoint, QPointF, QRect, QSize, Qt
+from qtpy.QtGui import QMouseEvent, QPaintEvent
 from qtpy.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -94,6 +94,7 @@ from PartSeg.common_gui.multiple_file_widget import (
     MultipleLoadDialog,
 )
 from PartSeg.common_gui.qt_modal import QtPopup
+from PartSeg.common_gui.qt_util import get_mouse_x, get_mouse_y
 from PartSeg.common_gui.searchable_combo_box import SearchComboBox
 from PartSeg.common_gui.show_directory_dialog import DirectoryDialog
 from PartSeg.common_gui.universal_gui_part import (
@@ -2050,3 +2051,17 @@ class TestSelectDirectoryDialog:
         w.accept()
         assert base_settings.get_path_history()
         assert Path(base_settings.get("s_path")).resolve() == (tmp_path / "sample_dir").resolve()
+
+
+@pytest.mark.usefixtures("qapp")
+def test_get_mouse_position():
+    event = QMouseEvent(
+        QEvent.Type.MouseButtonPress,
+        QPointF(10, 20),
+        QPointF(20, 30),
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    assert get_mouse_x(event) == 10
+    assert get_mouse_y(event) == 20

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ commands =
     python -m pytest --json-report --json-report-file={toxinidir}/report-{envname}-{sys_platform}.json {posargs:package/tests}
 
 
-[testenv:py{310,311,312,313,314,315}-PyQt5-coverage]
+[testenv:py{310,311,312,313,314,315}-{PyQt5,PyQt6}-coverage]
 deps =
     {[testenv]deps}
 commands =


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix get_mouse_y helper to return the event's Y position instead of the X position when using Qt6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vertical mouse-position reporting for Qt5 events.
  * Improved validation of mouse-coordinate reporting across supported Qt environments.

* **Quality Improvements**
  * Expanded automated coverage for both PyQt5 and PyQt6 to help ensure consistent behavior across supported Qt configurations.
  * Updated compatibility checks for supported Qt and Python combinations.
  * Strengthened repository workflow permissions for safer automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->