### PR TITLE
chore: Pin actions using hashes

### DIFF
--- a/.github/workflows/base_test_workflow.yml
+++ b/.github/workflows/base_test_workflow.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Download test data
         if: ${{ inputs.test_data }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: test_data
           path: test_data
@@ -126,7 +126,7 @@ jobs:
           UV_CONSTRAINT: ${{ inputs.napari == 'latest' && format('requirements/constraints_py{0}.txt', inputs.python_version ) || 'requirements/version_denylist.txt' }}
 
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: timing-report-${{ inputs.os }}-py-${{ inputs.python_version }}-${{ inputs.napari }}-${{ inputs.qt_backend }}-${{ inputs.coverage }}${{ inputs.artifact_suffix }}
           path: |
@@ -134,7 +134,7 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: ${{ inputs.coverage }}
         with:
           name: cov-reports-${{ inputs.os }}-py-${{ inputs.python_version }}-${{ inputs.napari }}-${{ inputs.qt_backend }}${{ inputs.artifact_suffix }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.3
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.3
+      uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -72,4 +72,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.3
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -96,7 +96,7 @@ jobs:
         shell: bash
 
       - name: Create Release
-        uses: "softprops/action-gh-release@v3"
+        uses: "softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64"  # v3.0.3
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           tag_name: ${{ github.ref }}
@@ -110,4 +110,4 @@ jobs:
 
       - name: Publish package distributions to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1 (v1.14.2)

--- a/.github/workflows/test_napari_repo.yml
+++ b/.github/workflows/test_napari_repo.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Report Failures
         if: ${{ failure() }}
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5  # v2.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -36,7 +36,7 @@ jobs:
       - shell: bash
         run: bash build_utils/download_data.sh
       - name: Upload test data
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: test_data
           path: test_data
@@ -69,7 +69,7 @@ jobs:
           wm: herbstluftwm
 
       - name: Download test data
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: test_data
           path: test_data
@@ -106,7 +106,7 @@ jobs:
       # If something goes wrong, we can open an issue in the repo
       - name: Report Failures
         if: ${{ failure() }}
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5  # v2.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM: ${{ matrix.platform }}
@@ -140,7 +140,7 @@ jobs:
         uv pip install -r requirements.txt
         uv pip install .
     - name: upload requirements
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: requirements
         path: requirements.txt
@@ -148,7 +148,7 @@ jobs:
       run: |
         python build_utils/create_and_pack_executable.py
     - name: Upload bundle
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: bundle
         path: dist2/
@@ -159,7 +159,7 @@ jobs:
       # If something goes wrong, we can open an issue in the repo
     - name: Report Failures
       if: ${{ failure() }}
-      uses: JasonEtco/create-an-issue@v2
+      uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5  # v2.9.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PLATFORM: "linux"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,7 +166,7 @@ jobs:
           pip install codecov
 
       - name: Download coverage data
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: cov-reports-*
           path: coverage
@@ -179,14 +179,14 @@ jobs:
           python -Im coverage report --format=markdown --skip-empty --skip-covered >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage_xml
           path: coverage.xml
           retention-days: 5
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -198,7 +198,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v4.0.1
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5  # v4.0.1
         with:
           miniforge-version: latest
           use-mamba: true
@@ -206,10 +206,10 @@ jobs:
           channel-priority: strict
           python-version: "3.12"
 
-      - uses: tlambert03/setup-qt-libs@v1
+      - uses: tlambert03/setup-qt-libs@19e4ef2d781d81f5f067182e228b54ec90d23b76  # v1.8
 
       - name: Download test data
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: test_data
           path: test_data
@@ -234,7 +234,7 @@ jobs:
         run: bash build_utils/create_environment_yml.sh
 
       - name: Upload environment file
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: environment
           path: environment.yml
@@ -245,7 +245,7 @@ jobs:
         run: sed -e "s/{sys_platform}/{platform}/g" tox.ini -i
 
       - name: Test with tox
-        uses: aganders3/headless-gui@v2
+        uses: aganders3/headless-gui@f85dd6316993505dfc5f21839d520ae440c84816  # v2.2
         with:
           run: conda run -n test --no-capture-output tox -e py312-PySide2-conda
         timeout-minutes: 60

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -52,7 +52,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create PR updating vendored modules
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           commit-message: Update bundle dependencies.
           branch: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
## Summary by Sourcery

Pin all GitHub Actions workflow dependencies to specific commits to make automation runs reproducible and reduce supply-chain risk.

Enhancements:
- Pin GitHub Actions dependencies to immutable commit hashes across testing, security scanning, release, publishing, reporting, and dependency-update workflows while retaining version comments for traceability.

CI:
- Improve CI supply-chain reproducibility and security by replacing mutable action tags and branches with verified commit references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Pinned automated workflow actions to immutable version references for more predictable and reproducible builds.
  - Updated several workflow action versions, including artifact handling, code analysis, testing, release publishing, and pull request automation.
  - Workflow behavior, job logic, and test execution remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->